### PR TITLE
fix: add missing web-search-plus env template

### DIFF
--- a/skills/web-search-plus/.env.example
+++ b/skills/web-search-plus/.env.example
@@ -1,0 +1,18 @@
+# Web Search Plus environment template
+#
+# You only need ONE provider to get started. Uncomment and fill the ones you use.
+
+# Search providers
+SERPER_API_KEY=
+TAVILY_API_KEY=
+EXA_API_KEY=
+YOU_API_KEY=
+KILOCODE_API_KEY=
+
+# Self-hosted SearXNG (optional)
+SEARXNG_INSTANCE_URL=
+# Set to 1 only if you intentionally use a private/loopback SearXNG instance.
+SEARXNG_ALLOW_PRIVATE=0
+
+# Optional cache override
+# WSP_CACHE_DIR=


### PR DESCRIPTION
## Summary

- add the missing `skills/web-search-plus/.env.example` file that the package metadata and onboarding flow already expect
- include the actual provider env vars read by `scripts/search.py`, including `KILOCODE_API_KEY` for the Perplexity path and `SEARXNG_INSTANCE_URL`
- keep the patch isolated to `skills/web-search-plus`, independent from the open template-scaffold and skill-creator PRs

## Validation

- static check confirmed `.env.example` now exists and is still listed in `skills/web-search-plus/package.json`
- static check confirmed the template contains `SERPER_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`, `YOU_API_KEY`, `KILOCODE_API_KEY`, and `SEARXNG_INSTANCE_URL`

## Notes

- this fixes a real onboarding/packaging mismatch: `test-auto-routing.sh` tells users to copy `.env.example`, but the file was missing from the repo and from packaged skill contents