### PR TITLE
fix: warn when README index pattern is missing

### DIFF
--- a/scripts/collect.sh
+++ b/scripts/collect.sh
@@ -253,25 +253,37 @@ except: print('')
         count=$((count+1))
     done
 
-    python3 -c "
+    if python3 -c "
 import re, sys
 rows = sys.argv[1]
 count = sys.argv[2]
 with open('$README', 'r') as f:
     content = f.read()
+# Always refresh the visible total, even if the detailed table layout no longer
+# matches the legacy flat-index template this script knows how to rewrite.
+content = re.sub(
+    r'## 📦 Skill Index \(\d+ skills\)',
+    f'## 📦 Skill Index ({count} skills)',
+    content,
+    count=1,
+)
 # Replace table content between | Skill | header and next ---
 table_header = '| Skill | Description | Category | Source | Added |'
 table_sep = '|---|---|---|---|---|'
 new_table = table_header + '\n' + table_sep + rows
-content = re.sub(
+content, replacements = re.subn(
     r'\| Skill \| Description \| Category \| Source \| Added \|.*?(?=\n---|\n##)',
     new_table,
     content, flags=re.DOTALL
 )
 with open('$README', 'w') as f:
     f.write(content)
-print(f'README updated: {count} skills in index')
-" "$rows" "$count" 2>/dev/null && ok "README updated ($count skills)"
+sys.exit(0 if replacements > 0 else 2)
+" "$rows" "$count" 2>/dev/null; then
+        ok "README updated ($count skills)"
+    else
+        warn "README skill count refreshed, but the legacy flat-table layout was not found; index rows were left unchanged"
+    fi
 }
 
 # ── Git commit & push ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- stop `scripts/collect.sh` from falsely reporting that the README skill index was updated when the current README no longer matches the script's legacy flat-table pattern
- still refresh the visible `## 📦 Skill Index (N skills)` count so the collector does not leave the top-level total stale
- emit a warning when the detailed row replacement does not happen, making the drift explicit instead of silent

## Validation

- `bash -n scripts/collect.sh`
- README fixture check confirmed `replacements=0` and `count_updated=True` for the current 2-column README layout

## Notes

- this PR stays independent from openclaw-master-skills `#1`, `#5`, and `#6`; it only touches the weekly collector script