### PR TITLE
fix: align deep-research-pro package contents

### DIFF
--- a/skills/deep-research-pro/README.md
+++ b/skills/deep-research-pro/README.md
@@ -23,7 +23,7 @@ clawdhub install deep-research-pro
 ### Manual
 ```bash
 cd your-workspace/skills
-git clone https://github.com/parags/deep-research-pro.git
+git clone https://github.com/paragshah/deep-research-pro.git
 ```
 
 ## Usage
@@ -39,37 +39,7 @@ Just ask your agent to research something:
 
 The agent will follow the workflow in `SKILL.md` to produce a comprehensive report.
 
-### CLI Tool
-
-The `scripts/research` tool can also be used standalone:
-
-```bash
-# Basic multi-query search
-./scripts/research "query 1" "query 2" "query 3"
-
-# Full research mode (web + news + fetch top pages)
-./scripts/research --full "AI agents 2026" "monetizing AI skills"
-
-# Save to file
-./scripts/research --full "topic" --output results.md
-
-# JSON output
-./scripts/research "topic" --json
-
-# Fetch specific URLs
-./scripts/research --fetch "https://example.com/article"
-```
-
-### Options
-
-| Flag | Description |
-|------|-------------|
-| `--full` | Enable news search + fetch top 3 pages |
-| `--news` | Include news search |
-| `--max N` | Max results per query (default 8) |
-| `--fetch-top N` | Fetch full text of top N results |
-| `--output FILE` | Save results to file |
-| `--json` | Output as JSON |
+This packaged skill currently ships only the authored skill content (`SKILL.md`) and metadata. It does not include a standalone research CLI in this repository snapshot.
 
 ## How It Works
 

--- a/skills/deep-research-pro/package.json
+++ b/skills/deep-research-pro/package.json
@@ -5,5 +5,5 @@
   "keywords": ["research", "search", "analysis", "citations", "reports", "duckduckgo"],
   "license": "MIT",
   "author": "AstralSage",
-  "files": ["SKILL.md", "scripts/research", "package.json"]
+  "files": ["SKILL.md", "package.json", "README.md"]
 }


### PR DESCRIPTION
## Summary

- remove the nonexistent `scripts/research` file from the published package manifest
- update the README so it no longer tells users to run a CLI that is not shipped in this repo snapshot
- align the manual clone URL in the README with the canonical repo URL already recorded in `SKILL.md`

## Validation

- static check confirmed `README.md` no longer references `scripts/research`
- static check confirmed `package.json` no longer lists `scripts/research` in `files`
- static check confirmed the README clone URL now matches the `SKILL.md` homepage URL
- static check confirmed every `package.json.files` entry exists on disk