### PR TITLE
feat(ai-model-router-v2): add MiniMax as cloud LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cp -r openclaw-master-skills/skills/<skill-name> ~/.openclaw/workspace/skills/
 
 | [`agentcreate`](skills/agentcreate/) | AI-powered OpenClaw agent creator — create and configure independent agents with model selection |
 | [`ai-model-router`](skills/ai-model-router/) | Intelligent AI model router, auto-switches between local and cloud models |
-| [`ai-model-router-v2`](skills/ai-model-router-v2/) | AI model router v2 — enhanced local/cloud auto-switching |
+| [`ai-model-router-v2`](skills/ai-model-router-v2/) | AI model router v2 — enhanced local/cloud auto-switching with Anthropic, OpenAI, and [MiniMax](https://www.minimaxi.com) support |
 | [`ai-news-aggregator-sl`](skills/ai-news-aggregator-sl/) | Fetches AI & tech news or custom topics via aggregated feeds |
 | [`ai-task-hub`](skills/ai-task-hub/) | AI task hub for image analysis, background removal, speech-to-text, TTS, and more |
 | [`creative-toolkit`](skills/creative-toolkit/) | Multi-provider image generation — Nanobanana, Seedream, GPT Image |

--- a/skills/ai-model-router-v2/SKILL.md
+++ b/skills/ai-model-router-v2/SKILL.md
@@ -47,12 +47,28 @@ Your Request → Analyze → Select Model
 | Feature | Status |
 |---------|--------|
 | Auto-detect local models | ✓ (Ollama, LM Studio) |
-| Cloud model registry | ✓ (7 built-in) |
+| Cloud model registry | ✓ (9 built-in: Anthropic, OpenAI, MiniMax) |
 | Privacy detection | ✓ (API keys, passwords) |
 | Context tracking | ✓ (conversations) |
 | JSON config | ✓ (optional) |
 | CLI interface | ✓ |
 | **Core code size** | **~200 lines** |
+
+## Cloud Models
+
+| Provider | Model | Power | Cost | Context |
+|----------|-------|-------|------|---------|
+| Anthropic | Claude Haiku 4 | 60 | 3 | — |
+| Anthropic | Claude Sonnet 4 | 80 | 5 | — |
+| Anthropic | Claude Opus 4 | 95 | 8 | — |
+| OpenAI | GPT-4o Mini | 50 | 1 | — |
+| OpenAI | GPT-4o | 85 | 5 | — |
+| [MiniMax](https://www.minimaxi.com) | MiniMax M2.7 | 85 | 3 | 1M |
+| [MiniMax](https://www.minimaxi.com) | MiniMax M2.7 Highspeed | 75 | 2 | 1M |
+| [MiniMax](https://www.minimaxi.com) | MiniMax M2.5 | 70 | 2 | 204K |
+| [MiniMax](https://www.minimaxi.com) | MiniMax M2.5 Highspeed | 60 | 1 | 204K |
+
+MiniMax models use an OpenAI-compatible API at `https://api.minimax.io/v1`. Set `MINIMAX_API_KEY` to enable.
 
 ## CLI
 

--- a/skills/ai-model-router-v2/skill/core/router.py
+++ b/skills/ai-model-router-v2/skill/core/router.py
@@ -161,6 +161,7 @@ class RouterCore:
             self.models = [
                 Model("ollama:llama3:8b", "Llama 3 8B", "Ollama", "local", 0, 35),
                 Model("anthropic:claude-haiku-4", "Claude Haiku 4", "Anthropic", "cloud", 3, 60, requires_api_key=True, api_key_env="ANTHROPIC_API_KEY"),
+                Model("minimax:MiniMax-M2.7", "MiniMax M2.7", "MiniMax", "cloud", 3, 85, requires_api_key=True, api_key_env="MINIMAX_API_KEY"),
             ]
             self.primary_id = self.models[0].id
             self.secondary_id = self.models[1].id

--- a/skills/ai-model-router-v2/skill/modules/detector.py
+++ b/skills/ai-model-router-v2/skill/modules/detector.py
@@ -102,6 +102,14 @@ class ModelDetector:
             ModelInfo("anthropic:claude-opus-4", "Claude Opus 4", "Anthropic", "cloud", 8, 95),
             ModelInfo("openai:gpt-4o-mini", "GPT-4o Mini", "OpenAI", "cloud", 1, 50),
             ModelInfo("openai:gpt-4o", "GPT-4o", "OpenAI", "cloud", 5, 85),
+            ModelInfo("minimax:MiniMax-M2.7", "MiniMax M2.7", "MiniMax", "cloud", 3, 85,
+                      capabilities=["chat", "vision", "tools"]),
+            ModelInfo("minimax:MiniMax-M2.7-highspeed", "MiniMax M2.7 Highspeed", "MiniMax", "cloud", 2, 75,
+                      capabilities=["chat", "vision", "tools"]),
+            ModelInfo("minimax:MiniMax-M2.5", "MiniMax M2.5", "MiniMax", "cloud", 2, 70,
+                      capabilities=["chat", "tools"]),
+            ModelInfo("minimax:MiniMax-M2.5-highspeed", "MiniMax M2.5 Highspeed", "MiniMax", "cloud", 1, 60,
+                      capabilities=["chat", "tools"]),
         ]
 
     def detect_all(self) -> List[ModelInfo]:

--- a/skills/ai-model-router-v2/tests/test_minimax_integration.py
+++ b/skills/ai-model-router-v2/tests/test_minimax_integration.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Integration tests for MiniMax model routing in ai-model-router-v2.
+
+These tests verify end-to-end routing behavior when MiniMax is configured
+as a cloud provider. They do NOT make live API calls to MiniMax.
+"""
+
+import os
+import sys
+import json
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "skill"))
+
+from core.router import RouterCore
+from modules.detector import ModelDetector
+
+
+class TestMiniMaxEndToEndRouting(unittest.TestCase):
+    """Integration tests for MiniMax routing with full config lifecycle."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.config_path = os.path.join(self.tmpdir, "models.json")
+
+    def _create_router_with_minimax_secondary(self):
+        """Create a router with MiniMax M2.7 as secondary model."""
+        config = {
+            "primary_model": {"id": "ollama:llama3:8b"},
+            "secondary_model": {"id": "minimax:MiniMax-M2.7"},
+            "models": [
+                {"id": "ollama:llama3:8b", "name": "Llama 3 8B", "provider": "Ollama",
+                 "type": "local", "cost_score": 0, "power_score": 35},
+                {"id": "minimax:MiniMax-M2.7", "name": "MiniMax M2.7", "provider": "MiniMax",
+                 "type": "cloud", "cost_score": 3, "power_score": 85,
+                 "requires_api_key": True, "api_key_env": "MINIMAX_API_KEY",
+                 "capabilities": ["chat", "vision", "tools"]},
+                {"id": "minimax:MiniMax-M2.5-highspeed", "name": "MiniMax M2.5 Highspeed",
+                 "provider": "MiniMax", "type": "cloud", "cost_score": 1, "power_score": 60,
+                 "requires_api_key": True, "api_key_env": "MINIMAX_API_KEY",
+                 "capabilities": ["chat", "tools"]},
+            ]
+        }
+        with open(self.config_path, "w") as f:
+            json.dump(config, f)
+        return RouterCore(config_path=self.config_path)
+
+    def test_complex_task_routing_to_minimax(self):
+        """Complex tasks should be routed to MiniMax M2.7 when configured as secondary."""
+        router = self._create_router_with_minimax_secondary()
+        tasks = [
+            "Design a scalable microservices architecture",
+            "Implement a comprehensive end-to-end testing framework",
+            "Analyze and optimize the database query performance",
+        ]
+        for task in tasks:
+            result = router.route(task)
+            self.assertEqual(result.model_id, "minimax:MiniMax-M2.7",
+                             f"Task '{task}' should route to MiniMax M2.7")
+
+    def test_simple_task_stays_local(self):
+        """Simple tasks should stay on local model, not MiniMax."""
+        router = self._create_router_with_minimax_secondary()
+        tasks = [
+            "What is a for loop?",
+            "Show me a Python syntax example",
+            "What is HTTP?",
+        ]
+        for task in tasks:
+            result = router.route(task)
+            self.assertEqual(result.model_id, "ollama:llama3:8b",
+                             f"Task '{task}' should stay on local model")
+
+    def test_model_list_includes_minimax(self):
+        """list_models should include MiniMax models."""
+        router = self._create_router_with_minimax_secondary()
+        models = router.list_models()
+        minimax_models = [m for m in models if m["provider"] == "MiniMax"]
+        self.assertEqual(len(minimax_models), 2)
+        model_ids = {m["id"] for m in minimax_models}
+        self.assertIn("minimax:MiniMax-M2.7", model_ids)
+        self.assertIn("minimax:MiniMax-M2.5-highspeed", model_ids)
+
+    def test_auto_detect_includes_minimax_in_registry(self):
+        """Auto-detect mode should discover MiniMax models from cloud registry."""
+        # No config file => auto-detect mode
+        no_config_path = os.path.join(self.tmpdir, "nonexistent.json")
+        router = RouterCore(config_path=no_config_path)
+        minimax_models = [m for m in router.models if m.provider == "MiniMax"]
+        self.assertGreater(len(minimax_models), 0,
+                           "Auto-detect should include MiniMax from cloud registry")
+
+    def test_status_with_minimax_secondary(self):
+        """Router status should reflect MiniMax as secondary."""
+        router = self._create_router_with_minimax_secondary()
+        status = router.get_status()
+        self.assertEqual(status["secondary_id"], "minimax:MiniMax-M2.7")
+
+    def test_privacy_override_prevents_minimax(self):
+        """Privacy-sensitive content should never route to MiniMax cloud."""
+        router = self._create_router_with_minimax_secondary()
+        sensitive_tasks = [
+            "password=hunter2secretword",
+            "Use API key sk-abcdefghijklmnop1234",
+            "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9abcdef",
+        ]
+        for task in sensitive_tasks:
+            result = router.route(task)
+            self.assertEqual(result.model_id, "ollama:llama3:8b",
+                             f"Sensitive task should not route to MiniMax: {task}")
+            self.assertGreater(len(result.privacy_detected), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/ai-model-router-v2/tests/test_minimax_unit.py
+++ b/skills/ai-model-router-v2/tests/test_minimax_unit.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Unit tests for MiniMax model integration in ai-model-router-v2."""
+
+import os
+import sys
+import json
+import tempfile
+import unittest
+
+# Add skill source to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "skill"))
+
+from modules.detector import ModelDetector, ModelInfo
+from core.router import RouterCore, Model, RouteResult
+
+
+class TestMiniMaxCloudRegistry(unittest.TestCase):
+    """Test MiniMax models in cloud registry."""
+
+    def setUp(self):
+        self.detector = ModelDetector()
+        self.registry = self.detector.get_cloud_registry()
+
+    def test_registry_contains_minimax_models(self):
+        """MiniMax models should be present in the cloud registry."""
+        minimax_models = [m for m in self.registry if m.provider == "MiniMax"]
+        self.assertEqual(len(minimax_models), 4)
+
+    def test_minimax_m27_in_registry(self):
+        """MiniMax M2.7 should be in the registry with correct attributes."""
+        m27 = next((m for m in self.registry if m.id == "minimax:MiniMax-M2.7"), None)
+        self.assertIsNotNone(m27)
+        self.assertEqual(m27.name, "MiniMax M2.7")
+        self.assertEqual(m27.provider, "MiniMax")
+        self.assertEqual(m27.type, "cloud")
+        self.assertEqual(m27.power_score, 85)
+        self.assertEqual(m27.cost_score, 3)
+
+    def test_minimax_m27_highspeed_in_registry(self):
+        """MiniMax M2.7 Highspeed should be in the registry."""
+        m27hs = next((m for m in self.registry if m.id == "minimax:MiniMax-M2.7-highspeed"), None)
+        self.assertIsNotNone(m27hs)
+        self.assertEqual(m27hs.name, "MiniMax M2.7 Highspeed")
+        self.assertEqual(m27hs.power_score, 75)
+        self.assertEqual(m27hs.cost_score, 2)
+
+    def test_minimax_m25_in_registry(self):
+        """MiniMax M2.5 should be in the registry."""
+        m25 = next((m for m in self.registry if m.id == "minimax:MiniMax-M2.5"), None)
+        self.assertIsNotNone(m25)
+        self.assertEqual(m25.name, "MiniMax M2.5")
+        self.assertEqual(m25.power_score, 70)
+        self.assertEqual(m25.cost_score, 2)
+
+    def test_minimax_m25_highspeed_in_registry(self):
+        """MiniMax M2.5 Highspeed should be in the registry."""
+        m25hs = next((m for m in self.registry if m.id == "minimax:MiniMax-M2.5-highspeed"), None)
+        self.assertIsNotNone(m25hs)
+        self.assertEqual(m25hs.name, "MiniMax M2.5 Highspeed")
+        self.assertEqual(m25hs.power_score, 60)
+        self.assertEqual(m25hs.cost_score, 1)
+
+    def test_minimax_models_are_cloud_type(self):
+        """All MiniMax models should be cloud type."""
+        minimax_models = [m for m in self.registry if m.provider == "MiniMax"]
+        for m in minimax_models:
+            self.assertEqual(m.type, "cloud")
+
+    def test_minimax_m27_capabilities(self):
+        """MiniMax M2.7 should have chat, vision, and tools capabilities."""
+        m27 = next((m for m in self.registry if m.id == "minimax:MiniMax-M2.7"), None)
+        self.assertIn("chat", m27.capabilities)
+        self.assertIn("vision", m27.capabilities)
+        self.assertIn("tools", m27.capabilities)
+
+    def test_minimax_m25_capabilities(self):
+        """MiniMax M2.5 should have chat and tools capabilities."""
+        m25 = next((m for m in self.registry if m.id == "minimax:MiniMax-M2.5"), None)
+        self.assertIn("chat", m25.capabilities)
+        self.assertIn("tools", m25.capabilities)
+        self.assertNotIn("vision", m25.capabilities)
+
+    def test_total_cloud_models_count(self):
+        """Registry should have 9 cloud models total (5 original + 4 MiniMax)."""
+        self.assertEqual(len(self.registry), 9)
+
+    def test_minimax_power_scores_ordered(self):
+        """MiniMax M2.7 should have higher power than M2.5 variants."""
+        minimax_models = {m.id: m for m in self.registry if m.provider == "MiniMax"}
+        self.assertGreater(
+            minimax_models["minimax:MiniMax-M2.7"].power_score,
+            minimax_models["minimax:MiniMax-M2.7-highspeed"].power_score,
+        )
+        self.assertGreater(
+            minimax_models["minimax:MiniMax-M2.7-highspeed"].power_score,
+            minimax_models["minimax:MiniMax-M2.5"].power_score,
+        )
+        self.assertGreater(
+            minimax_models["minimax:MiniMax-M2.5"].power_score,
+            minimax_models["minimax:MiniMax-M2.5-highspeed"].power_score,
+        )
+
+    def test_minimax_cost_scores_reasonable(self):
+        """MiniMax highspeed variants should be cheaper than standard."""
+        minimax_models = {m.id: m for m in self.registry if m.provider == "MiniMax"}
+        self.assertGreaterEqual(
+            minimax_models["minimax:MiniMax-M2.7"].cost_score,
+            minimax_models["minimax:MiniMax-M2.7-highspeed"].cost_score,
+        )
+        self.assertGreaterEqual(
+            minimax_models["minimax:MiniMax-M2.5"].cost_score,
+            minimax_models["minimax:MiniMax-M2.5-highspeed"].cost_score,
+        )
+
+
+class TestMiniMaxRouterFallback(unittest.TestCase):
+    """Test MiniMax in router fallback models."""
+
+    def test_fallback_includes_minimax(self):
+        """Router fallback models should include MiniMax M2.7."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, "models.json")
+            # Write a config that will trigger fallback path by importing from detector
+            router = RouterCore(config_path=config_path)
+            minimax_models = [m for m in router.models if m.provider == "MiniMax"]
+            self.assertGreater(len(minimax_models), 0)
+
+    def test_minimax_model_lookup_by_id(self):
+        """Router should find MiniMax models by ID."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, "models.json")
+            router = RouterCore(config_path=config_path)
+            m = router.get_model("minimax:MiniMax-M2.7")
+            self.assertIsNotNone(m)
+            self.assertEqual(m.name, "MiniMax M2.7")
+
+
+class TestMiniMaxRouting(unittest.TestCase):
+    """Test routing decisions involving MiniMax models."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        config_path = os.path.join(self.tmpdir, "models.json")
+        # Configure MiniMax as secondary (cloud) model
+        config = {
+            "primary_model": {"id": "ollama:llama3:8b"},
+            "secondary_model": {"id": "minimax:MiniMax-M2.7"},
+            "models": [
+                {"id": "ollama:llama3:8b", "name": "Llama 3 8B", "provider": "Ollama",
+                 "type": "local", "cost_score": 0, "power_score": 35},
+                {"id": "minimax:MiniMax-M2.7", "name": "MiniMax M2.7", "provider": "MiniMax",
+                 "type": "cloud", "cost_score": 3, "power_score": 85,
+                 "requires_api_key": True, "api_key_env": "MINIMAX_API_KEY"},
+            ]
+        }
+        with open(config_path, "w") as f:
+            json.dump(config, f)
+        self.router = RouterCore(config_path=config_path)
+
+    def test_simple_task_routes_to_primary(self):
+        """Simple tasks should route to primary (local) model."""
+        result = self.router.route("What is Python?")
+        self.assertEqual(result.model_type, "primary")
+        self.assertEqual(result.model_id, "ollama:llama3:8b")
+
+    def test_complex_task_routes_to_minimax(self):
+        """Complex tasks should route to MiniMax (secondary)."""
+        result = self.router.route("Design a scalable microservices architecture for an e-commerce platform")
+        self.assertEqual(result.model_type, "secondary")
+        self.assertEqual(result.model_id, "minimax:MiniMax-M2.7")
+        self.assertEqual(result.model_name, "MiniMax M2.7")
+
+    def test_force_secondary_routes_to_minimax(self):
+        """Force secondary should route to MiniMax."""
+        result = self.router.route("Hello", force="secondary")
+        self.assertEqual(result.model_id, "minimax:MiniMax-M2.7")
+        self.assertEqual(result.reason, "forced")
+
+    def test_privacy_routes_to_primary_not_minimax(self):
+        """Privacy-sensitive data should route to local, not MiniMax cloud."""
+        result = self.router.route("My API key is sk-1234567890abcdef")
+        self.assertEqual(result.model_type, "primary")
+        self.assertEqual(result.model_id, "ollama:llama3:8b")
+        self.assertGreater(len(result.privacy_detected), 0)
+
+    def test_route_result_has_correct_fields(self):
+        """Route result for MiniMax should contain all expected fields."""
+        result = self.router.route("Design a comprehensive end-to-end system", force="secondary")
+        self.assertIsInstance(result, RouteResult)
+        self.assertEqual(result.model_id, "minimax:MiniMax-M2.7")
+        self.assertEqual(result.model_name, "MiniMax M2.7")
+        self.assertIsInstance(result.confidence, float)
+
+
+class TestModelInfoDataclass(unittest.TestCase):
+    """Test ModelInfo dataclass for MiniMax models."""
+
+    def test_minimax_model_info_defaults(self):
+        """ModelInfo should have correct defaults for capabilities."""
+        m = ModelInfo("minimax:test", "Test", "MiniMax", "cloud")
+        self.assertEqual(m.capabilities, ["chat"])
+
+    def test_minimax_model_info_custom_capabilities(self):
+        """ModelInfo should accept custom capabilities."""
+        m = ModelInfo("minimax:test", "Test", "MiniMax", "cloud",
+                      capabilities=["chat", "vision", "tools"])
+        self.assertEqual(m.capabilities, ["chat", "vision", "tools"])
+
+
+class TestDetectAll(unittest.TestCase):
+    """Test detect_all includes MiniMax models."""
+
+    def test_detect_all_includes_minimax(self):
+        """detect_all should include MiniMax models from cloud registry."""
+        detector = ModelDetector()
+        all_models = detector.detect_all()
+        minimax_models = [m for m in all_models if m.provider == "MiniMax"]
+        self.assertEqual(len(minimax_models), 4)
+
+    def test_detect_all_minimax_ids(self):
+        """detect_all should have all 4 MiniMax model IDs."""
+        detector = ModelDetector()
+        all_models = detector.detect_all()
+        minimax_ids = {m.id for m in all_models if m.provider == "MiniMax"}
+        expected = {
+            "minimax:MiniMax-M2.7",
+            "minimax:MiniMax-M2.7-highspeed",
+            "minimax:MiniMax-M2.5",
+            "minimax:MiniMax-M2.5-highspeed",
+        }
+        self.assertEqual(minimax_ids, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add **MiniMax** M2.7, M2.7-highspeed, M2.5, and M2.5-highspeed models to the cloud model registry in the `ai-model-router-v2` skill
- MiniMax uses an OpenAI-compatible API at `https://api.minimax.io/v1`, configured via `MINIMAX_API_KEY` environment variable
- Include MiniMax M2.7 (1M context, vision+tools) in the router fallback models

## Changes

| File | Description |
|------|-------------|
| `detector.py` | Add 4 MiniMax models to `get_cloud_registry()` with cost/power scores and capabilities |
| `router.py` | Include MiniMax M2.7 in fallback models list |
| `SKILL.md` | Add Cloud Models table documenting all 9 built-in providers |
| `README.md` | Update ai-model-router-v2 description to mention MiniMax |
| `tests/test_minimax_unit.py` | 22 unit tests for registry, routing, and model lookup |
| `tests/test_minimax_integration.py` | 6 integration tests for end-to-end routing with MiniMax |

## MiniMax Models Added

| Model | Power | Cost | Context | Capabilities |
|-------|-------|------|---------|-------------|
| MiniMax M2.7 | 85 | 3 | 1M | chat, vision, tools |
| MiniMax M2.7 Highspeed | 75 | 2 | 1M | chat, vision, tools |
| MiniMax M2.5 | 70 | 2 | 204K | chat, tools |
| MiniMax M2.5 Highspeed | 60 | 1 | 204K | chat, tools |

## Test plan

- [x] 22 unit tests pass (registry, model lookup, routing decisions, capabilities, scores)
- [x] 6 integration tests pass (end-to-end routing, privacy override, auto-detect, config lifecycle)
- [ ] Manual: verify `python3 skill/core/router.py --list` shows MiniMax models
- [ ] Manual: verify complex tasks route to MiniMax when configured as secondary