### PR TITLE
Add three agent payment & web tool skills: agentwallet-sdk, agentpay-mcp, webmcp-sdk

### DIFF
--- a/skills/agentpay-mcp/SKILL.md
+++ b/skills/agentpay-mcp/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: agentpay-mcp
+description: MCP (Model Context Protocol) payment server for AI agents. Adds drop-in x402 Payment Required handling to Claude, LangChain, CrewAI, and other MCP-compatible agents. Automatically negotiates and completes 402 payment flows so agents can access pay-per-use APIs without manual payment logic.
+---
+
+# AgentPay MCP
+
+An MCP server that gives AI agents the ability to pay for services automatically. When an API returns an HTTP 402 Payment Required response, AgentPay MCP handles the full payment negotiation and retry cycle — no custom payment code required in the agent.
+
+- **GitHub**: https://github.com/up2itnow0822/agentpay-mcp
+- **npm**: `agentpay-mcp`
+
+## Core Capabilities
+
+- **Automatic 402 handling** — intercepts HTTP 402 responses and completes the payment flow transparently
+- **MCP-native** — exposes payment tools via the Model Context Protocol; works with any MCP host
+- **Multi-framework support** — compatible with Claude Desktop, LangChain, CrewAI, and custom MCP clients
+- **Configurable spend limits** — set per-request and session-level payment ceilings
+- **Audit log** — records every payment attempt and outcome for review
+
+## Setup
+
+```bash
+npm install -g agentpay-mcp
+```
+
+Set a wallet private key for the agent to sign payments:
+
+```bash
+export AGENTPAY_PRIVATE_KEY=0x...
+export AGENTPAY_MAX_PER_REQUEST=0.10   # USD ceiling per payment
+export AGENTPAY_MAX_PER_SESSION=1.00   # USD ceiling per session
+```
+
+## Claude Desktop Integration
+
+Add to `~/.config/claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "agentpay": {
+      "command": "agentpay-mcp",
+      "env": {
+        "AGENTPAY_PRIVATE_KEY": "0x...",
+        "AGENTPAY_MAX_PER_REQUEST": "0.10",
+        "AGENTPAY_MAX_PER_SESSION": "1.00"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The agent will now be able to call `agentpay_fetch` when it needs to access pay-per-use endpoints.
+
+## LangChain Integration
+
+```python
+from langchain_mcp import MCPToolkit
+
+toolkit = MCPToolkit(server_command=["agentpay-mcp"])
+tools = toolkit.get_tools()
+
+# Pass tools to your LangChain agent — payment handling is automatic
+agent = initialize_agent(tools, llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION)
+```
+
+## CrewAI Integration
+
+```python
+from crewai_tools import MCPServerAdapter
+
+agentpay_tools = MCPServerAdapter(
+    command="agentpay-mcp",
+    env={"AGENTPAY_PRIVATE_KEY": "0x..."}
+)
+
+agent = Agent(
+    role="Researcher",
+    tools=agentpay_tools.tools,
+    ...
+)
+```
+
+## MCP Tools Exposed
+
+| Tool | Description |
+|------|-------------|
+| `agentpay_fetch` | Fetch a URL; pays automatically if the server returns 402 |
+| `agentpay_status` | Show session spend total and remaining budget |
+| `agentpay_history` | List payment events for the current session |
+
+### agentpay_fetch
+
+```json
+{
+  "tool": "agentpay_fetch",
+  "arguments": {
+    "url": "https://api.example.com/data",
+    "method": "GET",
+    "maxPayment": "0.05"
+  }
+}
+```
+
+The server:
+1. Sends the request to the target URL
+2. If 200 — returns the response body directly
+3. If 402 — reads the `X-Payment` header, signs and submits payment, retries the request
+4. Returns the final response or an error if payment was refused or limits exceeded
+
+## x402 Payment Flow
+
+AgentPay MCP implements the [x402 protocol](https://x402.org):
+
+1. Agent calls `agentpay_fetch` with a URL
+2. Server receives HTTP `402 Payment Required` with payment details in headers
+3. AgentPay signs the payment using the configured private key
+4. Retries the original request with a `X-Payment` proof header
+5. Returns the unlocked response to the agent
+
+## Security Rules
+
+1. **Set spend limits.** Always configure `AGENTPAY_MAX_PER_REQUEST` and `AGENTPAY_MAX_PER_SESSION` before deploying.
+2. **Never expose private keys in logs or prompts.** Use environment variables only.
+3. **Review payment history periodically.** Use `agentpay_history` to audit what the agent paid for.
+4. **Test with low limits first.** Start with `maxPayment: 0.001` to verify the flow before raising limits.
+
+## References
+
+- GitHub: https://github.com/up2itnow0822/agentpay-mcp
+- npm: https://www.npmjs.com/package/agentpay-mcp
+- x402 protocol: https://x402.org
+- MCP specification: https://modelcontextprotocol.io

--- a/skills/agentwallet-sdk/SKILL.md
+++ b/skills/agentwallet-sdk/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: agentwallet-sdk
+description: Non-custodial wallet SDK for AI agents. Provides ERC-6551 token-bound accounts, on-chain SpendingPolicy limits, x402 payments, 17-chain CCTP bridging, Circle Nanopayments (gas-free micro-payments), and Uniswap V3 token swaps. Use when an agent needs to hold funds, pay for services, or move value across chains.
+metadata: '{"openclaw":{"requires":{"env":["AGENT_WALLET_PRIVATE_KEY"]}}}'
+---
+
+# AgentWallet SDK
+
+Non-custodial wallet SDK designed for AI agents. Each agent gets its own ERC-6551 token-bound account with on-chain spending controls, cross-chain bridging, and gas-free micro-payment rails.
+
+- **npm**: `agentwallet-sdk` (~1,200 downloads/week)
+- **GitHub**: https://github.com/up2itnow0822/agent-wallet-sdk
+
+## Core Capabilities
+
+- **ERC-6551 Token-Bound Accounts** — Agent identity and wallet tied to an NFT; portable across dApps
+- **SpendingPolicy** — On-chain per-period and per-transaction spend limits to constrain agent behavior
+- **x402 Payments** — HTTP 402 Payment Required flow for pay-per-use API calls
+- **CCTP Bridging** — Circle's Cross-Chain Transfer Protocol across 17 supported chains
+- **Circle Nanopayments** — Gas-free micro-payments for high-frequency, low-value transactions
+- **Uniswap V3 Swaps** — In-wallet token swaps via Uniswap V3 liquidity pools
+
+## Setup
+
+```bash
+npm install agentwallet-sdk
+```
+
+Set the agent's private key:
+
+```bash
+export AGENT_WALLET_PRIVATE_KEY=0x...
+```
+
+## Quick Start
+
+```typescript
+import { AgentWallet } from 'agentwallet-sdk';
+
+const wallet = new AgentWallet({
+  privateKey: process.env.AGENT_WALLET_PRIVATE_KEY,
+  chainId: 1, // Ethereum mainnet
+});
+
+// Check balance
+const balance = await wallet.getBalance();
+console.log(`Balance: ${balance.formatted} ETH`);
+```
+
+## SpendingPolicy
+
+Set on-chain limits to constrain how much an agent can spend autonomously:
+
+```typescript
+// Set a daily spend limit of 10 USDC
+await wallet.setSpendingPolicy({
+  periodLimit: '10', // USDC per period
+  perTxLimit: '2',   // max per single transaction
+  periodSeconds: 86400, // 24-hour rolling window
+  token: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC
+});
+```
+
+## x402 Payments
+
+Handle HTTP 402 Payment Required responses automatically:
+
+```typescript
+import { x402Fetch } from 'agentwallet-sdk';
+
+// Automatically pays when the server returns 402
+const response = await x402Fetch('https://api.example.com/premium-endpoint', {
+  wallet,
+  maxPayment: '0.01', // USDC ceiling
+});
+```
+
+## Cross-Chain Bridging (CCTP)
+
+Move USDC across 17 supported chains via Circle's CCTP:
+
+```typescript
+await wallet.bridge({
+  fromChain: 1,        // Ethereum
+  toChain: 8453,       // Base
+  amount: '5.00',      // USDC
+  token: 'USDC',
+});
+```
+
+Supported chains include Ethereum, Base, Arbitrum, Optimism, Polygon, Avalanche, and more.
+
+## Circle Nanopayments
+
+Send gas-free micro-payments using Circle's off-chain payment rails:
+
+```typescript
+await wallet.nanopay({
+  recipient: '0xRecipient...',
+  amount: '0.001', // USDC — gas-free at this scale
+});
+```
+
+## Uniswap V3 Swaps
+
+Swap tokens in-wallet without leaving the SDK:
+
+```typescript
+await wallet.swap({
+  tokenIn: 'ETH',
+  tokenOut: 'USDC',
+  amountIn: '0.01',
+  slippageTolerance: 0.5, // 0.5%
+});
+```
+
+## ERC-6551 Token-Bound Accounts
+
+Each agent wallet is tied to an NFT, giving agents a portable on-chain identity:
+
+```typescript
+// Deploy a token-bound account for an existing NFT
+const tba = await wallet.deployTokenBoundAccount({
+  nftContract: '0xNFTContract...',
+  tokenId: '42',
+});
+console.log(`Agent TBA address: ${tba.address}`);
+```
+
+## Security Rules
+
+1. **Never log or print private keys.** Use environment variables only.
+2. **Set SpendingPolicy before giving agents autonomy.** On-chain limits are the last line of defense.
+3. **Validate x402 payment amounts before signing.** Always cap with `maxPayment`.
+4. **Test on testnets first.** Use `chainId: 84532` (Base Sepolia) or `chainId: 11155111` (Sepolia) before mainnet.
+
+## References
+
+- GitHub: https://github.com/up2itnow0822/agent-wallet-sdk
+- npm: https://www.npmjs.com/package/agentwallet-sdk
+- ERC-6551 spec: https://eips.ethereum.org/EIPS/eip-6551
+- Circle CCTP docs: https://developers.circle.com/stablecoins/cctp-getting-started
+- x402 protocol: https://x402.org

--- a/skills/webmcp-sdk/SKILL.md
+++ b/skills/webmcp-sdk/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: webmcp-sdk
+description: Developer toolkit for building WebMCP-compliant tool servers. Implements the W3C WebMCP spec with tool registration, security middleware, rate limiting, audit logging, React hooks, and proxy relay. Use when you want a website or web service to expose structured tools that browser-based AI agents can discover and call.
+---
+
+# WebMCP SDK
+
+A developer toolkit for implementing the [WebMCP specification](https://webmcp.dev) — a W3C-proposed standard that lets websites expose structured tools for browser agents. Drop this SDK into any Node.js or React project to make your site agent-accessible.
+
+- **GitHub**: https://github.com/up2itnow0822/webmcp-sdk
+- **npm**: `webmcp-sdk`
+
+## Core Capabilities
+
+- **Tool registration** — Declare tools with typed schemas that agents can discover via `/.well-known/mcp.json`
+- **Security middleware** — Origin validation, CORS, CSP, and request signing
+- **Rate limiting** — Per-agent and per-tool rate limits to protect backend services
+- **Audit logging** — Structured logs of every tool call with caller identity and outcome
+- **React hooks** — `useWebMCP` and related hooks for React apps that want to surface tools client-side
+- **Proxy relay** — Route agent tool calls to internal services without exposing them directly
+
+## Setup
+
+```bash
+npm install webmcp-sdk
+```
+
+## Express / Node.js Server
+
+Expose tools from an existing Express app:
+
+```typescript
+import express from 'express';
+import { WebMCPServer, tool, z } from 'webmcp-sdk';
+
+const app = express();
+const mcp = new WebMCPServer({ app });
+
+// Register a tool
+mcp.register(
+  tool({
+    name: 'search_products',
+    description: 'Search the product catalog by keyword',
+    input: z.object({
+      query: z.string().describe('Search terms'),
+      limit: z.number().optional().default(10),
+    }),
+    handler: async ({ query, limit }) => {
+      const results = await db.products.search(query, limit);
+      return { results };
+    },
+  })
+);
+
+app.listen(3000);
+```
+
+Agents can now discover tools at `GET /.well-known/mcp.json` and call them via `POST /mcp/tools/{name}`.
+
+## React Hooks
+
+Expose tools from a client-side React app:
+
+```tsx
+import { useWebMCP, defineTool } from 'webmcp-sdk/react';
+
+const searchTool = defineTool({
+  name: 'search_ui',
+  description: 'Trigger a search in the current UI context',
+  input: z.object({ query: z.string() }),
+  handler: async ({ query }) => {
+    setSearchQuery(query); // update React state
+    return { triggered: true };
+  },
+});
+
+function App() {
+  useWebMCP({ tools: [searchTool] });
+  // ...
+}
+```
+
+## Security Middleware
+
+Enable built-in security controls:
+
+```typescript
+const mcp = new WebMCPServer({
+  app,
+  security: {
+    allowedOrigins: ['https://trusted-agent.example.com'],
+    requireSignedRequests: true, // verify HMAC on each call
+    csrfProtection: true,
+  },
+});
+```
+
+## Rate Limiting
+
+Protect tools from excessive calls:
+
+```typescript
+const mcp = new WebMCPServer({
+  app,
+  rateLimit: {
+    windowMs: 60_000,     // 1-minute window
+    maxPerAgent: 30,      // 30 calls per agent per minute
+    maxPerTool: 10,       // 10 calls per specific tool per minute
+  },
+});
+```
+
+## Audit Logging
+
+Every tool call is logged with caller identity and outcome:
+
+```typescript
+const mcp = new WebMCPServer({
+  app,
+  audit: {
+    enabled: true,
+    logger: (event) => {
+      // event: { tool, input, output, agentId, duration, status }
+      console.log(JSON.stringify(event));
+    },
+  },
+});
+```
+
+## Proxy Relay
+
+Route agent requests to internal microservices without exposing them:
+
+```typescript
+import { proxyRelay } from 'webmcp-sdk';
+
+// Forward tool calls matching a pattern to an internal service
+mcp.use(
+  proxyRelay({
+    match: /^internal_/,
+    target: 'http://internal-api:8080',
+    rewritePath: (name) => `/tools/${name}`,
+  })
+);
+```
+
+## Discovery Endpoint
+
+Once configured, agents discover available tools via the standard WebMCP manifest:
+
+```
+GET /.well-known/mcp.json
+```
+
+Response:
+
+```json
+{
+  "schema_version": "1.0",
+  "tools": [
+    {
+      "name": "search_products",
+      "description": "Search the product catalog by keyword",
+      "inputSchema": { ... }
+    }
+  ]
+}
+```
+
+## Security Rules
+
+1. **Restrict `allowedOrigins`** to known agent hosts in production.
+2. **Enable `requireSignedRequests`** for any tool that writes data or accesses sensitive information.
+3. **Set rate limits** before exposing tools publicly — agents can call rapidly.
+4. **Review audit logs** regularly for unexpected callers or tool abuse.
+5. **Do not expose internal service URLs** via tool descriptions or error messages.
+
+## References
+
+- GitHub: https://github.com/up2itnow0822/webmcp-sdk
+- npm: https://www.npmjs.com/package/webmcp-sdk
+- WebMCP specification: https://webmcp.dev


### PR DESCRIPTION
## New Skills

This PR adds three skills for AI agent payment infrastructure and web tool exposure.

---

### `agentwallet-sdk`
Non-custodial wallet SDK for AI agents.

- **ERC-6551 token-bound accounts** — agent identity tied to an NFT
- **SpendingPolicy** — on-chain per-period and per-transaction spend limits
- **x402 payments** — automatic HTTP 402 Payment Required flow
- **17-chain CCTP bridging** — move USDC across chains via Circle CCTP
- **Circle Nanopayments** — gas-free micro-payments
- **Uniswap V3 swaps** — in-wallet token swaps

npm: `agentwallet-sdk` (~1,200 downloads/week)
GitHub: https://github.com/up2itnow0822/agent-wallet-sdk

---

### `agentpay-mcp`
Drop-in MCP payment server for AI agents.

- Handles HTTP 402 Payment Required automatically
- Works with Claude Desktop, LangChain, CrewAI, and any MCP-compatible host
- Configurable per-request and per-session spend limits
- Session audit log of all payment events

npm: `agentpay-mcp`
GitHub: https://github.com/up2itnow0822/agentpay-mcp

---

### `webmcp-sdk`
Developer toolkit implementing the W3C WebMCP spec.

- Tool registration with typed schemas + auto-generated `/.well-known/mcp.json`
- Security middleware (origin allowlist, HMAC request signing, CSRF)
- Rate limiting per agent and per tool
- Structured audit logging
- React hooks (`useWebMCP`) for client-side tool exposure
- Proxy relay for routing agent calls to internal services

npm: `webmcp-sdk`
GitHub: https://github.com/up2itnow0822/webmcp-sdk

---

All three skills follow the existing SKILL.md format with YAML frontmatter, capability overview, setup instructions, code examples, and security rules.