### PR TITLE
fix(web-search): Add missing env template

### DIFF
--- a/skills/web-search-plus/.env.example
+++ b/skills/web-search-plus/.env.example
@@ -1,0 +1,18 @@
+# Web Search Plus environment template
+#
+# You only need ONE provider to get started. Uncomment and fill the ones you use.
+
+# Search providers
+SERPER_API_KEY=
+TAVILY_API_KEY=
+EXA_API_KEY=
+YOU_API_KEY=
+KILOCODE_API_KEY=
+
+# Self-hosted SearXNG (optional)
+SEARXNG_INSTANCE_URL=
+# Set to 1 only if you intentionally use a private/loopback SearXNG instance.
+SEARXNG_ALLOW_PRIVATE=0
+
+# Optional cache override
+# WSP_CACHE_DIR=


### PR DESCRIPTION
## Summary

- refresh the old `web-search-plus` env-template fix onto current `main`
- keep the missing `skills/web-search-plus/.env.example` in the package so setup docs and package metadata match the shipped files
- include the provider/env vars that `scripts/search.py` actually reads, plus the optional cache directory example

## Validation

- static check confirmed `skills/web-search-plus/.env.example` exists
- static check confirmed the template still contains `SERPER_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`, `YOU_API_KEY`, `KILOCODE_API_KEY`, `SEARXNG_INSTANCE_URL`, `SEARXNG_ALLOW_PRIVATE`, and optional `WSP_CACHE_DIR`
- static check confirmed those env vars are the ones referenced by `skills/web-search-plus/scripts/search.py`
