### PR TITLE
fix(skill-creator): Allow version and author in frontmatter

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -4,27 +4,45 @@ Quick validation script for skills - minimal version
 """
 
 import sys
-import os
 import re
 import yaml
+from collections.abc import Mapping
 from pathlib import Path
+from typing import cast
 
-def validate_skill(skill_path):
+
+ALLOWED_PROPERTIES = {
+    "name",
+    "description",
+    "license",
+    "allowed-tools",
+    "metadata",
+    "compatibility",
+    "version",
+    "author",
+}
+
+
+def _safe_load_frontmatter(frontmatter_text: str) -> object:
+    return cast(object, yaml.safe_load(frontmatter_text))
+
+
+def validate_skill(skill_path: str | Path) -> tuple[bool, str]:
     """Basic validation of a skill"""
     skill_path = Path(skill_path)
 
     # Check SKILL.md exists
-    skill_md = skill_path / 'SKILL.md'
+    skill_md = skill_path / "SKILL.md"
     if not skill_md.exists():
         return False, "SKILL.md not found"
 
     # Read and validate frontmatter
     content = skill_md.read_text()
-    if not content.startswith('---'):
+    if not content.startswith("---"):
         return False, "No YAML frontmatter found"
 
     # Extract frontmatter
-    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
     if not match:
         return False, "Invalid frontmatter format"
 
@@ -32,14 +50,15 @@ def validate_skill(skill_path):
 
     # Parse YAML frontmatter
     try:
-        frontmatter = yaml.safe_load(frontmatter_text)
-        if not isinstance(frontmatter, dict):
+        parsed_frontmatter = _safe_load_frontmatter(frontmatter_text)
+        if not isinstance(parsed_frontmatter, Mapping):
             return False, "Frontmatter must be a YAML dictionary"
+        parsed_frontmatter = cast(Mapping[object, object], parsed_frontmatter)
+        frontmatter: dict[str, object] = {
+            str(key): value for key, value in parsed_frontmatter.items()
+        }
     except yaml.YAMLError as e:
         return False, f"Invalid YAML in frontmatter: {e}"
-
-    # Define allowed properties
-    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
 
     # Check for unexpected properties (excluding nested keys under metadata)
     unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
@@ -50,54 +69,73 @@ def validate_skill(skill_path):
         )
 
     # Check required fields
-    if 'name' not in frontmatter:
+    if "name" not in frontmatter:
         return False, "Missing 'name' in frontmatter"
-    if 'description' not in frontmatter:
+    if "description" not in frontmatter:
         return False, "Missing 'description' in frontmatter"
 
     # Extract name for validation
-    name = frontmatter.get('name', '')
+    name = frontmatter.get("name", "")
     if not isinstance(name, str):
         return False, f"Name must be a string, got {type(name).__name__}"
     name = name.strip()
     if name:
         # Check naming convention (kebab-case: lowercase with hyphens)
-        if not re.match(r'^[a-z0-9-]+$', name):
-            return False, f"Name '{name}' should be kebab-case (lowercase letters, digits, and hyphens only)"
-        if name.startswith('-') or name.endswith('-') or '--' in name:
-            return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+        if not re.match(r"^[a-z0-9-]+$", name):
+            return (
+                False,
+                f"Name '{name}' should be kebab-case (lowercase letters, digits, and hyphens only)",
+            )
+        if name.startswith("-") or name.endswith("-") or "--" in name:
+            return (
+                False,
+                f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens",
+            )
         # Check name length (max 64 characters per spec)
         if len(name) > 64:
-            return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
+            return (
+                False,
+                f"Name is too long ({len(name)} characters). Maximum is 64 characters.",
+            )
 
     # Extract and validate description
-    description = frontmatter.get('description', '')
+    description = frontmatter.get("description", "")
     if not isinstance(description, str):
         return False, f"Description must be a string, got {type(description).__name__}"
     description = description.strip()
     if description:
         # Check for angle brackets
-        if '<' in description or '>' in description:
+        if "<" in description or ">" in description:
             return False, "Description cannot contain angle brackets (< or >)"
         # Check description length (max 1024 characters per spec)
         if len(description) > 1024:
-            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+            return (
+                False,
+                f"Description is too long ({len(description)} characters). Maximum is 1024 characters.",
+            )
 
     # Validate compatibility field if present (optional)
-    compatibility = frontmatter.get('compatibility', '')
+    compatibility = frontmatter.get("compatibility", "")
     if compatibility:
         if not isinstance(compatibility, str):
-            return False, f"Compatibility must be a string, got {type(compatibility).__name__}"
+            return (
+                False,
+                f"Compatibility must be a string, got {type(compatibility).__name__}",
+            )
         if len(compatibility) > 500:
-            return False, f"Compatibility is too long ({len(compatibility)} characters). Maximum is 500 characters."
+            return (
+                False,
+                f"Compatibility is too long ({len(compatibility)} characters). Maximum is 500 characters.",
+            )
 
     return True, "Skill is valid!"
+
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
         print("Usage: python quick_validate.py <skill_directory>")
         sys.exit(1)
-    
+
     valid, message = validate_skill(sys.argv[1])
     print(message)
     sys.exit(0 if valid else 1)

--- a/skills/skill-creator/scripts/test_quick_validate.py
+++ b/skills/skill-creator/scripts/test_quick_validate.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+import importlib.util
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from typing import Callable, cast
+
+
+MODULE_PATH = Path(__file__).with_name("quick_validate.py")
+MODULE_SPEC = importlib.util.spec_from_file_location("quick_validate", MODULE_PATH)
+if MODULE_SPEC is None or MODULE_SPEC.loader is None:
+    raise RuntimeError(f"Unable to load quick_validate.py from {MODULE_PATH}")
+QUICK_VALIDATE = importlib.util.module_from_spec(MODULE_SPEC)
+_ = MODULE_SPEC.loader.exec_module(QUICK_VALIDATE)
+validate_skill = cast(
+    Callable[[str | Path], tuple[bool, str]], QUICK_VALIDATE.validate_skill
+)
+
+
+class ValidateSkillTests(unittest.TestCase):
+    def make_skill(self, root: Path, frontmatter: str) -> Path:
+        skill_dir = root / "demo-skill"
+        skill_dir.mkdir()
+        _ = (skill_dir / "SKILL.md").write_text(
+            textwrap.dedent(frontmatter).strip() + "\n"
+        )
+        return skill_dir
+
+    def test_allows_version_and_author_frontmatter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = self.make_skill(
+                Path(tmp),
+                """
+                ---
+                name: demo-skill
+                description: Demo skill for validation
+                version: 1.0.0
+                author: example.com/demo
+                license: MIT
+                ---
+                """,
+            )
+
+            valid, message = validate_skill(skill_dir)
+
+            self.assertTrue(valid)
+            self.assertEqual(message, "Skill is valid!")
+
+    def test_rejects_unexpected_frontmatter_keys(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = self.make_skill(
+                Path(tmp),
+                """
+                ---
+                name: demo-skill
+                description: Demo skill for validation
+                unsupported: true
+                ---
+                """,
+            )
+
+            valid, message = validate_skill(skill_dir)
+
+            self.assertFalse(valid)
+            self.assertIn("unsupported", message)
+
+
+if __name__ == "__main__":
+    _ = unittest.main()


### PR DESCRIPTION
## Summary

- refresh the old `skill-creator` frontmatter compatibility fix onto current `main`
- accept `version` and `author` fields in frontmatter validation while preserving strict checks for genuinely unknown fields
- keep focused tests for the accepted frontmatter keys and the unknown-key rejection path

## Validation

- `python3 -m py_compile skills/skill-creator/scripts/quick_validate.py skills/skill-creator/scripts/test_quick_validate.py`
- `python3 -m unittest skills/skill-creator/scripts/test_quick_validate.py`
