### PR TITLE
feat: add x402 and payai skills (Solana + EVM agent payments)

### DIFF
--- a/skills/payai/README.md
+++ b/skills/payai/README.md
@@ -1,0 +1,72 @@
+# PayAI Agent Skill
+
+Discover, pay for, and sell agent services over the [x402 protocol](https://x402.gitbook.io/x402) using the [PayAI Network](https://payai.network) — USDC settlement on **Solana** and **EVM** chains, no signup.
+
+## What is this?
+
+This is an [Agent Skill](https://agentskills.io) for **PayAI**, the payment network for autonomous agents. It teaches an agent to:
+
+- **Browse the Bazaar** — a live directory of paid x402 APIs and agent services (`/discovery/resources`).
+- **Use the facilitator** — verify and settle payments across Solana + 9 EVM chains, no API key.
+- **Sell services** — turn any HTTP endpoint into a paid, discoverable x402 resource.
+
+For the mechanics of building and signing a payment, pair this with the companion [`x402`](../x402/) skill.
+
+## Install
+
+### Claude Code
+
+```bash
+mkdir -p ~/.claude/skills/payai
+cp -r SKILL.md scripts ~/.claude/skills/payai/
+```
+
+### OpenAI Codex
+
+```bash
+mkdir -p ~/.codex/skills/payai
+cp -r SKILL.md scripts ~/.codex/skills/payai/
+```
+
+### VS Code / GitHub Copilot
+
+```bash
+mkdir -p .github/skills/payai
+cp -r SKILL.md scripts .github/skills/payai/
+```
+
+Works with any agent that supports the [Agent Skills](https://agentskills.io) standard.
+
+## Try it (safe, no spend)
+
+`scripts/discover.mjs` lists live paid services from the PayAI Bazaar (zero dependencies, Node 18+):
+
+```bash
+node scripts/discover.mjs                  # recent resources
+node scripts/discover.mjs --network solana # only Solana-payable
+node scripts/discover.mjs --query weather  # filter by keyword
+```
+
+## Key details
+
+| Feature | Detail |
+|---|---|
+| Facilitator | `https://facilitator.payai.network` (no signup) |
+| Bazaar | `GET /discovery/resources` |
+| Chains | Solana + 9 EVM (Base, Polygon, Arbitrum, Avalanche, Sei, X Layer, SKALE) |
+| Asset | USDC (6 decimals) |
+| Solana gas | Paid by the facilitator |
+| Sell | `x402-express` / `x402-hono` / `x402-next` middleware |
+
+## Links
+
+- **Website:** https://payai.network
+- **Docs:** https://docs.payai.network
+- **Bazaar (live):** https://facilitator.payai.network/discovery/resources
+- **Supported networks (live):** https://facilitator.payai.network/supported
+- **Companion skill:** [`x402`](../x402/) — pay for any 402-gated resource
+- **Example consumer:** [`sp3nd`](../sp3nd/) — buy from Amazon with USDC via PayAI
+
+## License
+
+MIT

--- a/skills/payai/SKILL.md
+++ b/skills/payai/SKILL.md
@@ -41,6 +41,7 @@ The response is a paginated list of resources:
       "resource": "https://tripadvisor.x402.paysponge.com/api/v1/location/:locationId/details",
       "type": "http",
       "method": "GET",
+      "x402Version": 2,
       "accepts": [
         {
           "scheme": "exact",
@@ -64,6 +65,7 @@ Each item tells you everything needed to call and pay for it:
 
 - **`resource`** — the URL to call (with `:param` path params described in `inputSchema`).
 - **`method`** — HTTP verb.
+- **`x402Version`** — the item's protocol version. **v2** items use CAIP-2 networks (`eip155:8453`, `solana:<genesis>`) and the `PAYMENT-SIGNATURE` header; **v1** items use plain names (`base`) and `X-PAYMENT`. (The discovery envelope's own `x402Version` is separate — read each item's.)
 - **`accepts`** — the same payment-requirements array you'd get from a `402` (network, asset, price, `payTo`).
 - **`inputSchema` / `outputSchema`** — how to call it and what comes back.
 
@@ -71,7 +73,7 @@ Each item tells you everything needed to call and pay for it:
 
 1. **Search** the Bazaar for a resource that does what you need (filter `items` by keywords in `resource`, or by a `network`/asset you hold).
 2. **Read the price** from `accepts[].amount` (base units; USDC = 6 decimals).
-3. **Call + pay** using the [`x402`](../x402/) skill — send the request, get a `402`, build the payment, retry with `X-PAYMENT`.
+3. **Call + pay** using the [`x402`](../x402/) skill — send the request, get a `402`, build the payment, retry with the payment header (`X-PAYMENT` for v1, `PAYMENT-SIGNATURE` for v2 — matched to the item's `x402Version`).
 
 `scripts/discover.mjs` (zero dependencies, Node 18+) fetches the Bazaar and prints a readable table, with optional filtering:
 
@@ -122,34 +124,47 @@ POST /settle
 → { "success": true, "transaction": "<signature-or-hash>", "network": "solana", "payer": "…" }
 ```
 
-Servers usually call `/verify` + `/settle` for you when you send an `X-PAYMENT` header. Some flows (e.g. the [`sp3nd`](../sp3nd/) skill in this repo) have the **client** call `/verify` then `/settle` directly. The payload shapes are defined by the [`x402`](../x402/) skill.
+Servers usually call `/verify` + `/settle` for you when you send the payment header (`X-PAYMENT` in v1, `PAYMENT-SIGNATURE` in v2). Some flows (e.g. the [`sp3nd`](../sp3nd/) skill in this repo) have the **client** call `/verify` then `/settle` directly. The payload shapes are defined by the [`x402`](../x402/) skill.
 
 ## Part 3 — Sell your own services (get paid by agents)
 
 Any HTTP endpoint can become a paid, discoverable x402 resource:
 
-1. **Gate the route** so it returns `402 Payment Required` with an `accepts` array (your `network`, `asset`, `payTo`, and price). The x402 server middlewares make this a few lines:
-   - `x402-express`, `x402-hono`, `x402-next` — wrap a route and point the facilitator at `https://facilitator.payai.network`.
-2. **Settle** incoming payments via the PayAI facilitator (`/verify` + `/settle`) — the middleware does this automatically.
-3. **Get discovered** — resources that settle through PayAI are indexed into the Bazaar (`/discovery/resources`) so other agents can find and pay you. See the seller/merchant guide at https://docs.payai.network.
+1. **Gate the route** so it returns `402 Payment Required` with an `accepts` array (your `scheme`, `network`, `payTo`, and price). The x402 server middlewares make this a few lines: **v2** — `@x402/express`, `@x402/hono`, `@x402/next` (built on `@x402/core` + a scheme from `@x402/evm` / `@x402/svm`); **v1** — `x402-express`, `x402-hono`, `x402-next`.
+2. **Settle** incoming payments via the PayAI facilitator — point the middleware's facilitator client at `https://facilitator.payai.network` and it calls `/verify` + `/settle` for you.
+3. **Get discovered** — to appear in the Bazaar (`/discovery/resources`), a **v2** route must declare the discovery extension with `declareDiscoveryExtension()` from `@x402/extensions/bazaar` (hand-rolling `extensions.bazaar.schema` passes through but **fails silently** in the discovery crawler). See the seller guide at https://docs.payai.network.
 
-Conceptually (Express):
+Conceptually, a v2 Express seller settled by PayAI:
 
 ```javascript
+// npm i @x402/express @x402/core @x402/evm
 import express from "express";
-import { paymentMiddleware } from "x402-express";
+import { paymentMiddleware } from "@x402/express";
+import { x402ResourceServer, HTTPFacilitatorClient } from "@x402/core/server";
+import { ExactEvmScheme } from "@x402/evm/exact/server";
 
 const app = express();
+const payTo = "0xYourWallet";
+
+const facilitator = new HTTPFacilitatorClient({ url: "https://facilitator.payai.network" }); // PayAI settles
+const server = new x402ResourceServer(facilitator);
+server.register("eip155:*", new ExactEvmScheme());   // add ExactSvmScheme from @x402/svm for Solana
+
 app.use(paymentMiddleware(
-  "0xYourWallet",                                   // where you get paid
-  { "GET /premium": { price: "$0.01", network: "base" } },
-  { url: "https://facilitator.payai.network" },     // PayAI settles it
+  {
+    "GET /premium": {
+      accepts: [{ scheme: "exact", price: "$0.01", network: "eip155:8453", payTo }], // CAIP-2
+      description: "Premium content",
+      mimeType: "application/json",
+    },
+  },
+  server,
 ));
 app.get("/premium", (_req, res) => res.json({ data: "🎁 paid content" }));
 app.listen(3000);
 ```
 
-> Confirm the exact middleware signature against the x402 docs (https://x402.gitbook.io/x402) and PayAI's seller docs — the pricing/route config format evolves. Start on a testnet (`base-sepolia`, `solana-devnet`).
+> Confirm exact signatures against the x402 docs (https://x402.gitbook.io/x402) and PayAI's seller docs — config formats evolve. Start on a testnet (`base-sepolia`, `solana-devnet`).
 
 ## A real consumer in this repo
 
@@ -162,6 +177,6 @@ The [`sp3nd`](../sp3nd/) skill (buy from Amazon with USDC) settles every order t
 - **Verify / settle:** `POST /verify`, `POST /settle` with `{ paymentPayload, paymentRequirements }`.
 - **Supported:** `GET /supported` — Solana (+ gas paid for you) and 9 EVM chains.
 - **Asset:** USDC, 6 decimals. Solana mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`; Base contract `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`.
-- **Pay mechanics:** see the [`x402`](../x402/) skill.
-- **Seller middlewares:** `x402-express`, `x402-hono`, `x402-next`.
+- **Pay mechanics + v1/v2 headers:** see the [`x402`](../x402/) skill (v2 uses `PAYMENT-SIGNATURE` / `PAYMENT-RESPONSE`; v1 uses `X-PAYMENT` / `X-PAYMENT-RESPONSE`).
+- **Seller middlewares:** v2 — `@x402/express`, `@x402/hono`, `@x402/next` (+ `@x402/extensions/bazaar` for discovery); v1 — `x402-express`, `x402-hono`, `x402-next`.
 - **Website:** https://payai.network · **Docs:** https://docs.payai.network

--- a/skills/payai/SKILL.md
+++ b/skills/payai/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: payai
+description: Discover, pay for, and sell agent services over the x402 protocol using the PayAI Network. Browse the PayAI Bazaar — a live directory of paid APIs and agent services — pay any of them autonomously with USDC on Solana or EVM chains via the open PayAI facilitator, and expose your own endpoints as x402-monetized resources so other agents pay you. Use when an agent needs to find a paid tool/API/service, settle an x402 payment across chains, or accept crypto payments for the work it does.
+metadata: {"openclaw":{"emoji":"🌐","homepage":"https://payai.network","primaryEnv":"SOLANA_PRIVATE_KEY"}}
+---
+
+# PayAI — The Payment Network for Autonomous Agents
+
+## What is PayAI?
+
+**PayAI** is an open payment network that lets AI agents **find, pay for, and sell** services to each other using the [x402 protocol](https://x402.gitbook.io/x402) — HTTP-native payments settled in stablecoins (USDC). It has three parts an agent cares about:
+
+1. **The facilitator** (`https://facilitator.payai.network`) — a neutral, no-signup service that **verifies** and **settles** x402 payments across many chains. It settles **Solana** (and pays the gas for you) and **9 EVM chains**.
+2. **The Bazaar** (`/discovery/resources`) — a live, queryable directory of paid x402 resources: APIs, tools, and agent services you can call and pay for right now.
+3. **Merchant support** — libraries and facilitator endpoints that let *your* agent price an endpoint in USDC and get paid by other agents.
+
+Think of PayAI as the marketplace + settlement layer. This skill covers **discovering** services and **selling** yours. For the mechanics of *constructing and signing a payment*, use the companion [`x402`](../x402/) skill.
+
+## When to use this skill
+
+- You need a capability (data, inference, a tool, a physical good) and want to **find an agent/API that sells it**.
+- You have an x402 payment to **verify or settle** and need a facilitator.
+- You want to know **which chains/assets** are supported before paying.
+- You want to **monetize** your own agent or API so other agents pay you in USDC.
+
+## Part 1 — Discover services (the Bazaar)
+
+Query the live directory of paid resources:
+
+```bash
+curl -s "https://facilitator.payai.network/discovery/resources?limit=25" | jq
+```
+
+The response is a paginated list of resources:
+
+```json
+{
+  "x402Version": 1,
+  "items": [
+    {
+      "resource": "https://tripadvisor.x402.paysponge.com/api/v1/location/:locationId/details",
+      "type": "http",
+      "method": "GET",
+      "accepts": [
+        {
+          "scheme": "exact",
+          "network": "eip155:8453",
+          "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          "payTo": "0x6302D9e6DBB22fEC3c350551568Bb39B4b35Ad57",
+          "amount": "10000",
+          "maxTimeoutSeconds": 300
+        }
+      ],
+      "inputSchema": { "type": "http", "method": "GET", "pathParams": { "locationId": "154943" } },
+      "outputSchema": { "type": "json", "example": {} },
+      "lastUpdated": "2026-07-24T05:18:11.665Z"
+    }
+  ],
+  "pagination": { "limit": 25, "offset": 0 }
+}
+```
+
+Each item tells you everything needed to call and pay for it:
+
+- **`resource`** — the URL to call (with `:param` path params described in `inputSchema`).
+- **`method`** — HTTP verb.
+- **`accepts`** — the same payment-requirements array you'd get from a `402` (network, asset, price, `payTo`).
+- **`inputSchema` / `outputSchema`** — how to call it and what comes back.
+
+### Workflow: find → pay → use
+
+1. **Search** the Bazaar for a resource that does what you need (filter `items` by keywords in `resource`, or by a `network`/asset you hold).
+2. **Read the price** from `accepts[].amount` (base units; USDC = 6 decimals).
+3. **Call + pay** using the [`x402`](../x402/) skill — send the request, get a `402`, build the payment, retry with `X-PAYMENT`.
+
+`scripts/discover.mjs` (zero dependencies, Node 18+) fetches the Bazaar and prints a readable table, with optional filtering:
+
+```bash
+node scripts/discover.mjs                 # list recent resources
+node scripts/discover.mjs --network solana # only Solana-payable resources
+node scripts/discover.mjs --query weather  # match resource URL/description
+```
+
+## Part 2 — The facilitator API
+
+Base URL: `https://facilitator.payai.network`. No API key, no signup.
+
+### `GET /supported` — which chains & schemes settle
+
+```bash
+curl -s https://facilitator.payai.network/supported | jq '.kinds[] | {scheme, network}'
+```
+
+Returns the authoritative list. Currently:
+
+| Chain | Networks | x402 versions |
+|---|---|---|
+| **Solana** | `solana`, `solana-devnet`, `solana:<genesis>` (v2) | v1 + v2 |
+| **Base** | `base`, `base-sepolia`, `eip155:8453` | v1 + v2 (incl. `upto`) |
+| **Polygon** | `polygon`, `polygon-amoy`, `eip155:137` | v1 + v2 |
+| **Arbitrum** | `arbitrum`, `arbitrum-sepolia`, `eip155:42161` | v1 + v2 |
+| **Avalanche** | `avalanche`, `avalanche-fuji`, `eip155:43114` | v1 + v2 |
+| **Sei** | `sei`, `sei-testnet`, `eip155:1329` | v1 + v2 |
+| **X Layer** | `xlayer`, `xlayer-testnet`, `eip155:196` | v1 + v2 |
+| **SKALE** | `skale-base`, `skale-base-sepolia` | v1 + v2 |
+
+On Solana, the facilitator is the **fee payer** — the payer spends only USDC, no SOL. Always trust the live `/supported` output over this table.
+
+### `POST /verify` — check a payment is valid (no settlement)
+
+```json
+POST /verify
+{ "paymentPayload": { … }, "paymentRequirements": { … } }
+→ { "isValid": true, "payer": "…" }
+```
+
+### `POST /settle` — broadcast/settle the payment on-chain
+
+```json
+POST /settle
+{ "paymentPayload": { … }, "paymentRequirements": { … } }
+→ { "success": true, "transaction": "<signature-or-hash>", "network": "solana", "payer": "…" }
+```
+
+Servers usually call `/verify` + `/settle` for you when you send an `X-PAYMENT` header. Some flows (e.g. the [`sp3nd`](../sp3nd/) skill in this repo) have the **client** call `/verify` then `/settle` directly. The payload shapes are defined by the [`x402`](../x402/) skill.
+
+## Part 3 — Sell your own services (get paid by agents)
+
+Any HTTP endpoint can become a paid, discoverable x402 resource:
+
+1. **Gate the route** so it returns `402 Payment Required` with an `accepts` array (your `network`, `asset`, `payTo`, and price). The x402 server middlewares make this a few lines:
+   - `x402-express`, `x402-hono`, `x402-next` — wrap a route and point the facilitator at `https://facilitator.payai.network`.
+2. **Settle** incoming payments via the PayAI facilitator (`/verify` + `/settle`) — the middleware does this automatically.
+3. **Get discovered** — resources that settle through PayAI are indexed into the Bazaar (`/discovery/resources`) so other agents can find and pay you. See the seller/merchant guide at https://docs.payai.network.
+
+Conceptually (Express):
+
+```javascript
+import express from "express";
+import { paymentMiddleware } from "x402-express";
+
+const app = express();
+app.use(paymentMiddleware(
+  "0xYourWallet",                                   // where you get paid
+  { "GET /premium": { price: "$0.01", network: "base" } },
+  { url: "https://facilitator.payai.network" },     // PayAI settles it
+));
+app.get("/premium", (_req, res) => res.json({ data: "🎁 paid content" }));
+app.listen(3000);
+```
+
+> Confirm the exact middleware signature against the x402 docs (https://x402.gitbook.io/x402) and PayAI's seller docs — the pricing/route config format evolves. Start on a testnet (`base-sepolia`, `solana-devnet`).
+
+## A real consumer in this repo
+
+The [`sp3nd`](../sp3nd/) skill (buy from Amazon with USDC) settles every order through the **PayAI facilitator** on **Solana** — a working example of x402 + PayAI end to end.
+
+## Key facts
+
+- **Facilitator:** `https://facilitator.payai.network` — no signup, multi-chain.
+- **Bazaar / discovery:** `GET /discovery/resources` (paginated `items[]`).
+- **Verify / settle:** `POST /verify`, `POST /settle` with `{ paymentPayload, paymentRequirements }`.
+- **Supported:** `GET /supported` — Solana (+ gas paid for you) and 9 EVM chains.
+- **Asset:** USDC, 6 decimals. Solana mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`; Base contract `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`.
+- **Pay mechanics:** see the [`x402`](../x402/) skill.
+- **Seller middlewares:** `x402-express`, `x402-hono`, `x402-next`.
+- **Website:** https://payai.network · **Docs:** https://docs.payai.network

--- a/skills/payai/_meta.json
+++ b/skills/payai/_meta.json
@@ -1,0 +1,10 @@
+{
+  "owner": "PayAINetwork",
+  "slug": "payai",
+  "displayName": "PayAI — Payment Network for Agents",
+  "latest": {
+    "version": "1.0.0",
+    "publishedAt": 1784871635427
+  },
+  "history": []
+}

--- a/skills/payai/scripts/discover.mjs
+++ b/skills/payai/scripts/discover.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// discover.mjs — Browse the PayAI Bazaar: live x402 paid resources you can call.
+//
+// Usage:
+//   node discover.mjs [--network <name>] [--query <text>] [--limit <n>] [--json]
+//
+// Examples:
+//   node discover.mjs                     # recent resources
+//   node discover.mjs --network solana    # only resources payable on Solana
+//   node discover.mjs --query weather     # match resource URL / description
+//
+// Zero dependencies — requires Node 18+ (global fetch).
+
+const FACILITATOR = process.env.PAYAI_FACILITATOR || "https://facilitator.payai.network";
+
+const args = process.argv.slice(2);
+let network, query, limit = 25, asJson = false;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--network") network = (args[++i] || "").toLowerCase();
+  else if (args[i] === "--query") query = (args[++i] || "").toLowerCase();
+  else if (args[i] === "--limit") limit = Number(args[++i]) || 25;
+  else if (args[i] === "--json") asJson = true;
+  else if (args[i] === "-h" || args[i] === "--help") {
+    console.log("Usage: node discover.mjs [--network <name>] [--query <text>] [--limit <n>] [--json]");
+    process.exit(0);
+  }
+}
+
+const ASSETS = {
+  EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: { symbol: "USDC", decimals: 6 },
+  "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913":  { symbol: "USDC", decimals: 6 },
+};
+const assetInfo = a => ASSETS[a] || ASSETS[String(a).toLowerCase()] || { symbol: "token", decimals: 6 };
+
+function human(baseUnits, decimals) {
+  try {
+    const n = BigInt(baseUnits), d = BigInt(10) ** BigInt(decimals);
+    const frac = (n % d).toString().padStart(decimals, "0").replace(/0+$/, "");
+    return frac ? `${n / d}.${frac}` : `${n / d}`;
+  } catch { return String(baseUnits); }
+}
+
+const res = await fetch(`${FACILITATOR}/discovery/resources?limit=${Math.max(limit * 3, 50)}`);
+if (!res.ok) {
+  console.error(`Failed to reach Bazaar: HTTP ${res.status} ${res.statusText}`);
+  process.exit(1);
+}
+const data = await res.json();
+let items = data.items || [];
+
+if (network) items = items.filter(it => (it.accepts || []).some(a => String(a.network).toLowerCase().includes(network)));
+if (query)   items = items.filter(it => JSON.stringify(it).toLowerCase().includes(query));
+items = items.slice(0, limit);
+
+if (asJson) { console.log(JSON.stringify(items, null, 2)); process.exit(0); }
+
+console.log(`\nPayAI Bazaar — ${items.length} resource(s)  (facilitator: ${FACILITATOR})`);
+if (network) console.log(`filter: network~="${network}"`);
+if (query)   console.log(`filter: query~="${query}"`);
+
+for (const it of items) {
+  const opts = (it.accepts || []).map(a => {
+    const info = assetInfo(a.asset);
+    const amt = a.maxAmountRequired ?? a.amount;
+    return `${human(amt, info.decimals)} ${info.symbol} on ${a.network}`;
+  });
+  console.log(`\n• ${it.method || "GET"} ${it.resource}`);
+  if (it.accepts?.[0]?.description) console.log(`  ${it.accepts[0].description}`);
+  console.log(`  pay: ${opts.join("  |  ") || "(no accepts listed)"}`);
+  if (it.accepts?.[0]?.payTo) console.log(`  payTo: ${it.accepts[0].payTo}`);
+}
+
+console.log(`\nTo call + pay one of these, use the companion \`x402\` skill.`);

--- a/skills/x402/README.md
+++ b/skills/x402/README.md
@@ -1,0 +1,71 @@
+# x402 Agent Skill
+
+Pay for any HTTP 402-gated API, tool, or resource autonomously with USDC — on **Solana** and **EVM** chains — using the [x402 payment protocol](https://x402.gitbook.io/x402) and the open [PayAI](https://payai.network) facilitator.
+
+## What is this?
+
+This is an [Agent Skill](https://agentskills.io) that teaches an AI agent how to **be the payer** in an x402 flow: detect an `HTTP 402 Payment Required` response, build and sign a stablecoin payment, and retry the request with an `X-PAYMENT` header — no accounts, no API keys, no human checkout.
+
+To **discover** paid services and **sell** your own, use the companion [`payai`](../payai/) skill.
+
+## Install
+
+### Claude Code
+
+```bash
+mkdir -p ~/.claude/skills/x402
+cp -r SKILL.md scripts ~/.claude/skills/x402/
+```
+
+### OpenAI Codex
+
+```bash
+mkdir -p ~/.codex/skills/x402
+cp -r SKILL.md scripts ~/.codex/skills/x402/
+```
+
+### VS Code / GitHub Copilot
+
+```bash
+mkdir -p .github/skills/x402
+cp -r SKILL.md scripts .github/skills/x402/
+```
+
+Works with any agent that supports the [Agent Skills](https://agentskills.io) standard (Claude Code, Codex CLI, Copilot, Cursor, Windsurf, Goose, Gemini CLI, and more).
+
+## What agents can do
+
+1. **Detect** an `HTTP 402` and parse the `accepts` payment requirements.
+2. **Pay on Solana** — USDC transfer where the facilitator pays gas (you spend no SOL).
+3. **Pay on EVM** — Base, Polygon, Arbitrum, Avalanche, Sei, and more, via EIP-3009.
+4. **Retry** the request with `X-PAYMENT` and receive the resource.
+
+## Try it (safe, no spend)
+
+`scripts/inspect-402.mjs` probes a URL and prints the payment requirements without paying anything (zero dependencies, Node 18+):
+
+```bash
+node scripts/inspect-402.mjs https://api.example.com/paid-endpoint
+```
+
+## Key details
+
+| Feature | Detail |
+|---|---|
+| Protocol | x402 (`HTTP 402 Payment Required`) |
+| Chains | Solana + 9 EVM chains (Base, Polygon, Arbitrum, Avalanche, Sei, X Layer, SKALE) |
+| Asset | USDC (6 decimals) |
+| Facilitator | `https://facilitator.payai.network` |
+| Solana gas | Paid by the facilitator, not you |
+| Signup / KYC | None |
+
+## Links
+
+- **x402 protocol docs:** https://x402.gitbook.io/x402
+- **PayAI facilitator docs:** https://docs.payai.network
+- **Supported networks (live):** https://facilitator.payai.network/supported
+- **Companion skill:** [`payai`](../payai/) — discover & sell x402 services
+
+## License
+
+MIT

--- a/skills/x402/SKILL.md
+++ b/skills/x402/SKILL.md
@@ -16,12 +16,26 @@ The whole thing happens in a single retried HTTP request:
 1. Agent  → GET/POST  https://api.example.com/paid-endpoint
 2. Server → 402 Payment Required   { accepts: [ { network, asset, amount, payTo, ... } ] }
 3. Agent  → build + sign a stablecoin payment, re-send the SAME request
-            with header:  X-PAYMENT: <base64 payment payload>
+            with the payment header  (X-PAYMENT in v1, PAYMENT-SIGNATURE in v2)
 4. Server → verifies + settles the payment via a facilitator, then returns
-            200 OK  + the resource  + header  X-PAYMENT-RESPONSE: <base64 receipt>
+            200 OK  + the resource  + a settlement-receipt header
 ```
 
 Because payment is just an HTTP header, x402 works with any HTTP client and any agent framework. This skill teaches you how to **be the payer (client)**. To *discover* paid services and to *sell* your own, see the companion [`payai`](../payai/) skill.
+
+## Protocol versions: v1 vs v2 (READ THIS)
+
+x402 has two wire versions in the wild, and the **header names differ**. A `402` response tells you which one you're dealing with via its `x402Version` field (and its network format). The PayAI facilitator supports **both** — always match what the server offered.
+
+| | **v1** (`x402Version: 1`) | **v2** (`x402Version: 2`) |
+|---|---|---|
+| Requirements (server → client) | JSON body `accepts` (some servers also use a `PAYMENT-REQUIRED` header) | **`PAYMENT-REQUIRED`** header, base64 (often also in the body) |
+| Payment (client → server) | **`X-PAYMENT`** | **`PAYMENT-SIGNATURE`** |
+| Receipt (server → client) | `X-PAYMENT-RESPONSE` | `PAYMENT-RESPONSE` |
+| Network id | plain string — `base`, `solana` | **CAIP-2** — `eip155:8453`, `solana:<genesis-hash>` |
+| Client packages | `x402-fetch`, `x402-axios` | `@x402/fetch`, `@x402/axios` + `@x402/evm` / `@x402/svm` |
+
+**Rule of thumb for the manual flow:** read `x402Version` from the 402 response, then use the matching payment header (`x402Version >= 2` → `PAYMENT-SIGNATURE`, else `X-PAYMENT`) and echo that same version number back in your payload. Never hardcode the `network` string — copy the exact value from the `accepts` entry (it may be `solana` **or** `solana:5eykt4Us…`).
 
 ## When to use this skill
 
@@ -44,7 +58,7 @@ Reach for x402 whenever you encounter any of these:
 
 ## The payment requirements object
 
-When a server returns `402`, the body (or, for some servers, a `PAYMENT-REQUIRED` header) contains an `accepts` array. Each entry describes one way to pay:
+When a server returns `402`, an `accepts` array describes the ways to pay. In **v1** it's in the JSON body; in **v2** it's a base64-encoded `PAYMENT-REQUIRED` **header** (and usually mirrored in the body too — decode whichever is present). Each entry describes one option:
 
 ```json
 {
@@ -82,32 +96,46 @@ Pick the `accepts` entry whose `network` matches a chain you hold USDC on. If se
 
 ### Option A — Use an x402 client library (recommended)
 
-The x402 ecosystem ships drop-in HTTP wrappers that detect a `402`, pay it, and transparently retry — turning "pay for this" into a normal `fetch`:
+The x402 ecosystem ships drop-in HTTP wrappers that detect a `402`, pay it, and transparently retry — turning "pay for this" into a normal `fetch`. **You don't choose a facilitator as the payer** — the *seller* runs one and settles your payment; you just sign. The wrapper also picks the right header (`X-PAYMENT` vs `PAYMENT-SIGNATURE`) for the version the server offered.
 
-- `x402-fetch` — wraps the native `fetch`
-- `x402-axios` — an Axios interceptor
-
-Point the wrapper's facilitator at PayAI and hand it a wallet. Conceptually:
+**v2 (current — builder pattern, registers a scheme per chain):**
 
 ```javascript
-import { wrapFetchWithPayment } from "x402-fetch";
-// signer = your Solana or EVM wallet/keypair
-const fetchWithPay = wrapFetchWithPayment(fetch, signer, {
-  facilitator: { url: "https://facilitator.payai.network" },
-});
+// npm i @x402/fetch @x402/core @x402/evm @x402/svm
+import { x402Client } from "@x402/core";
+import { wrapFetchWithPayment } from "@x402/fetch";
+import { ExactEvmScheme } from "@x402/evm/exact/client";
+import { ExactSvmScheme } from "@x402/svm/exact/client";
 
-// Just call the paid endpoint — payment happens automatically on 402:
-const res = await fetchWithPay("https://api.example.com/paid-endpoint");
+const client = new x402Client();
+client.register("eip155:*", new ExactEvmScheme(evmSigner));   // any EVM chain
+client.register("solana:*", new ExactSvmScheme(svmSigner));   // any Solana cluster
+
+const fetchWithPay = wrapFetchWithPayment(fetch, client);
+const res  = await fetchWithPay("https://api.example.com/paid-endpoint"); // pays on 402
 const data = await res.json();
 ```
 
-> Library APIs evolve — confirm the exact signature against the x402 docs (https://x402.gitbook.io/x402) and PayAI's facilitator docs (https://docs.payai.network). If a library doesn't yet support your chain (Solana support is newer than EVM), fall back to Option B.
+**v1 (legacy — still accepted by the facilitator):**
+
+```javascript
+// npm i x402-fetch
+import { wrapFetchWithPayment } from "x402-fetch";
+const fetchWithPay = wrapFetchWithPayment(fetch, walletClient); // EVM wallet or Solana signer
+const res = await fetchWithPay("https://api.example.com/paid-endpoint");
+```
+
+`x402-axios` / `@x402/axios` provide the same thing as an Axios interceptor.
+
+> Library APIs evolve — confirm exact signatures against the x402 docs (https://x402.gitbook.io/x402) and PayAI's docs (https://docs.payai.network). Solana (`@x402/svm`) is newer than EVM; if a library path doesn't fit, fall back to Option B.
 
 ### Option B — Manual flow (works everywhere, no SDK)
 
 This is the fully-explicit flow. It always works because it only uses the wallet SDK for your chain plus `fetch`.
 
-#### B.1 — Solana (USDC, facilitator pays gas)
+#### B.1 — Solana (USDC, facilitator pays gas) — **v1 wire format**
+
+This builds the **v1** Solana payment (`X-PAYMENT`), which the PayAI facilitator still accepts. It's the simplest correct manual path. For strict **v2** Solana endpoints, see the note after the code.
 
 ```javascript
 // npm i @solana/web3.js @solana/spl-token
@@ -123,11 +151,11 @@ const connection  = new Connection(process.env.SOLANA_RPC_URL || "https://api.ma
 const keypair     = Keypair.fromSecretKey(Uint8Array.from(JSON.parse(process.env.SOLANA_PRIVATE_KEY)));
 
 async function payX402Solana(url, init = {}) {
-  // 1. Trigger the 402
+  // 1. Trigger the 402 and read the requirements from the JSON body
   let res = await fetch(url, init);
   if (res.status !== 402) return res;              // nothing to pay
-  const body = await res.clone().json().catch(() => null);
-  const req  = (body?.accepts || []).find(a => a.network?.startsWith("solana"));
+  const reqs = await res.clone().json().catch(() => null);
+  const req  = (reqs?.accepts || []).find(a => String(a.network).startsWith("solana"));
   if (!req) throw new Error("No Solana payment option offered");
 
   // 2. Build a USDC transfer where the FACILITATOR is the fee payer
@@ -150,25 +178,27 @@ async function payX402Solana(url, init = {}) {
   const tx = new VersionedTransaction(message.compileToV0Message());
   tx.sign([keypair]);                                        // you sign as the token owner; facilitator co-signs on settle
 
-  // 3. Encode the x402 payment payload and re-send the request with X-PAYMENT
+  // 3. Encode the v1 payment payload and re-send the request with X-PAYMENT
   const paymentPayload = {
-    x402Version: req.x402Version ?? 1,
+    x402Version: 1,
     scheme: "exact",
-    network: req.network,
+    network: req.network,                                     // echo the exact string the server gave
     payload: { transaction: Buffer.from(tx.serialize()).toString("base64") },
   };
   const header = Buffer.from(JSON.stringify(paymentPayload)).toString("base64");
 
   res = await fetch(url, { ...init, headers: { ...(init.headers || {}), "X-PAYMENT": header } });
-  return res;                                                // 200 OK + X-PAYMENT-RESPONSE receipt header
+  return res;                                                 // 200 OK + X-PAYMENT-RESPONSE receipt
 }
 ```
 
-> **Some servers settle server-side** (they read your `X-PAYMENT` header, call the facilitator, then return the resource). **Others** — like the `sp3nd` skill in this repo — ask the client to call the facilitator's `/verify` then `/settle` directly and confirm out of band. Read the server's docs. The facilitator endpoints are: `POST /verify` and `POST /settle`, each taking `{ paymentPayload, paymentRequirements }` and returning `{ isValid }` / `{ success, transaction }`.
+> **Some servers settle server-side** (they read your payment header, call the facilitator, then return the resource). **Others** — like the `sp3nd` skill in this repo — ask the client to call the facilitator's `/verify` then `/settle` directly and confirm out of band. Read the server's docs. The facilitator endpoints are: `POST /verify` and `POST /settle`, each taking `{ paymentPayload, paymentRequirements }` and returning `{ isValid }` / `{ success, transaction }`.
+
+> **Paying a strict v2 Solana endpoint?** v2 changes the wire format: the header is `PAYMENT-SIGNATURE`, and the payload is a different envelope — `{ x402Version: 2, resource, accepted, payload: { transaction } }` (where `accepted` is the `accepts` entry you chose). The signed transaction must also include a **Memo** instruction — the seller's `extra.memo` if present, otherwise a random nonce for replay protection. Rather than hand-roll all that, use **`@x402/svm`** (Option A) — it builds the v2 payload, memo/nonce, and blockhash pinning correctly. The manual code above is the simpler v1 format.
 
 #### B.2 — EVM (Base, Polygon, Arbitrum, …) via EIP-3009
 
-On EVM, the `exact` scheme uses an **EIP-3009 `transferWithAuthorization`** signature — you sign a typed message authorizing the transfer; no on-chain tx or gas from you at signing time. The payload is:
+On EVM, the `exact` scheme uses an **EIP-3009 `transferWithAuthorization`** signature — you sign a typed message authorizing the transfer; no on-chain tx or gas from you at signing time. The **v1** payload is:
 
 ```json
 {
@@ -189,7 +219,7 @@ On EVM, the `exact` scheme uses an **EIP-3009 `transferWithAuthorization`** sign
 }
 ```
 
-Base64-encode that and send it as `X-PAYMENT`, exactly as in the Solana case. The easiest way to produce the signature correctly is the `x402-fetch` / `x402-axios` library (Option A), which handles the EIP-712 domain and nonce for you.
+Base64-encode that and send it as `X-PAYMENT`, exactly as in the Solana v1 case. **v2** uses `PAYMENT-SIGNATURE` with a different envelope (`{ x402Version: 2, resource, accepted, payload }`) and CAIP-2 networks (`eip155:8453`). Producing the EIP-712 signature by hand is error-prone in either version — use `@x402/fetch` + `@x402/evm` (Option A), which builds the signature, envelope, and header for you.
 
 ## Choosing a facilitator
 
@@ -228,13 +258,15 @@ Use it to confirm the network, asset, amount, and `payTo` **before** wiring up a
 ## Key facts
 
 - **Protocol:** x402 (`HTTP 402 Payment Required`) — payment as an HTTP header.
-- **Payment header (client → server):** `X-PAYMENT: base64(paymentPayload)`.
-- **Receipt header (server → client):** `X-PAYMENT-RESPONSE: base64(settlementReceipt)`.
+- **Requirements header (v2, server → client):** `PAYMENT-REQUIRED: base64(requirements)` (v1 puts them in the JSON body).
+- **Payment header (client → server):** `PAYMENT-SIGNATURE` in **v2**, `X-PAYMENT` in **v1** — base64(paymentPayload).
+- **Receipt header (server → client):** `PAYMENT-RESPONSE` in **v2**, `X-PAYMENT-RESPONSE` in **v1**.
+- **Pick the version** from the 402's `x402Version`; the facilitator accepts both.
 - **Default facilitator:** `https://facilitator.payai.network` (Solana + 9 EVM chains).
 - **USDC decimals:** 6 (so `1000000` base units = $1.00).
 - **USDC mint (Solana mainnet):** `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
 - **USDC contract (Base mainnet):** `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
 - **Solana gas:** paid by the facilitator (`extra.feePayer`), not by you.
-- **Client libraries:** `x402-fetch`, `x402-axios`.
+- **Client libraries:** v2 — `@x402/fetch`, `@x402/axios` (+ `@x402/evm`, `@x402/svm`); v1 — `x402-fetch`, `x402-axios`.
 - **Discover & sell x402 services:** see the [`payai`](../payai/) skill.
 - **Docs:** x402 protocol — https://x402.gitbook.io/x402 · PayAI facilitator — https://docs.payai.network

--- a/skills/x402/SKILL.md
+++ b/skills/x402/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: x402
+description: Pay for any HTTP 402-gated API, tool, or resource autonomously with stablecoins (USDC) over the x402 payment protocol — on Solana and EVM chains (Base, Polygon, Arbitrum, Avalanche, Sei, and more) — using the open PayAI facilitator. Use whenever an agent hits an HTTP 402 Payment Required response, needs to call a paid API without signing up for an account or API key, or wants to buy machine-priced services with crypto and no human in the loop.
+metadata: {"openclaw":{"emoji":"💸","homepage":"https://payai.network","primaryEnv":"SOLANA_PRIVATE_KEY"}}
+---
+
+# x402 — Pay for Anything on the Web with One Line of Crypto
+
+## What is x402?
+
+**x402** is an open payment protocol that revives the long-dormant `HTTP 402 Payment Required` status code so that **machines can pay machines**. A server prices a resource; a client (your agent) pays for it inline with a stablecoin transfer; the server delivers the resource. No accounts, no API keys, no OAuth, no credit card, no human checkout.
+
+The whole thing happens in a single retried HTTP request:
+
+```
+1. Agent  → GET/POST  https://api.example.com/paid-endpoint
+2. Server → 402 Payment Required   { accepts: [ { network, asset, amount, payTo, ... } ] }
+3. Agent  → build + sign a stablecoin payment, re-send the SAME request
+            with header:  X-PAYMENT: <base64 payment payload>
+4. Server → verifies + settles the payment via a facilitator, then returns
+            200 OK  + the resource  + header  X-PAYMENT-RESPONSE: <base64 receipt>
+```
+
+Because payment is just an HTTP header, x402 works with any HTTP client and any agent framework. This skill teaches you how to **be the payer (client)**. To *discover* paid services and to *sell* your own, see the companion [`payai`](../payai/) skill.
+
+## When to use this skill
+
+Reach for x402 whenever you encounter any of these:
+
+- A request comes back **`402 Payment Required`** (check `response.status === 402`).
+- You need data or compute from a **paid API** but have no account or API key for it.
+- A task would be faster/cheaper done by **paying a specialized agent or tool** than doing it yourself.
+- You are wiring an agent to **buy machine-priced resources** (inference, data, files, RPC calls, physical goods) with USDC autonomously.
+
+## Prerequisites
+
+| You need | Why |
+|---|---|
+| A funded **wallet** on the payment chain | To hold the USDC you'll spend. Solana keypair, or an EVM private key. |
+| **USDC** in that wallet | The near-universal x402 settlement asset (a 1:1 USD stablecoin). |
+| A **facilitator** URL | A service that verifies and broadcasts your payment. Default: `https://facilitator.payai.network` (multi-chain). |
+
+> On **Solana**, you do **not** need SOL for gas — the facilitator acts as the transaction **fee payer**. You only spend USDC. On EVM chains, gas handling depends on the scheme (see below).
+
+## The payment requirements object
+
+When a server returns `402`, the body (or, for some servers, a `PAYMENT-REQUIRED` header) contains an `accepts` array. Each entry describes one way to pay:
+
+```json
+{
+  "x402Version": 1,
+  "error": "Payment required",
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "solana",
+      "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "payTo": "2nkTRv3qxk7n2eYYjFAndReVXaV7sTF3Z9pNimvp5jcp",
+      "maxAmountRequired": "10000",
+      "resource": "https://api.example.com/paid-endpoint",
+      "description": "1 API call",
+      "mimeType": "application/json",
+      "maxTimeoutSeconds": 300,
+      "extra": { "feePayer": "2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4" }
+    }
+  ]
+}
+```
+
+Field notes:
+
+- **`scheme`** — almost always `"exact"` (pay an exact amount). PayAI also supports `"upto"` on EVM for metered/streaming usage.
+- **`network`** — `"solana"` / `"solana-devnet"`, or an EVM name like `"base"`, or a v2 CAIP-2 id like `"eip155:8453"` (Base) / `"solana:5eykt4Us..."`.
+- **`asset`** — the token to pay in. On Solana it's the USDC **mint** (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`). On Base it's the USDC contract (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`).
+- **`maxAmountRequired`** (a.k.a. `amount`) — the price in the asset's **base units** (USDC has **6 decimals**, so `10000` = $0.01).
+- **`payTo`** — the recipient (the seller's wallet / token account).
+- **`extra.feePayer`** — on Solana, the facilitator wallet that pays network gas. Set this as your transaction's fee payer.
+
+Pick the `accepts` entry whose `network` matches a chain you hold USDC on. If several match, prefer the cheapest / a chain you already have funds on.
+
+## Two ways to pay
+
+### Option A — Use an x402 client library (recommended)
+
+The x402 ecosystem ships drop-in HTTP wrappers that detect a `402`, pay it, and transparently retry — turning "pay for this" into a normal `fetch`:
+
+- `x402-fetch` — wraps the native `fetch`
+- `x402-axios` — an Axios interceptor
+
+Point the wrapper's facilitator at PayAI and hand it a wallet. Conceptually:
+
+```javascript
+import { wrapFetchWithPayment } from "x402-fetch";
+// signer = your Solana or EVM wallet/keypair
+const fetchWithPay = wrapFetchWithPayment(fetch, signer, {
+  facilitator: { url: "https://facilitator.payai.network" },
+});
+
+// Just call the paid endpoint — payment happens automatically on 402:
+const res = await fetchWithPay("https://api.example.com/paid-endpoint");
+const data = await res.json();
+```
+
+> Library APIs evolve — confirm the exact signature against the x402 docs (https://x402.gitbook.io/x402) and PayAI's facilitator docs (https://docs.payai.network). If a library doesn't yet support your chain (Solana support is newer than EVM), fall back to Option B.
+
+### Option B — Manual flow (works everywhere, no SDK)
+
+This is the fully-explicit flow. It always works because it only uses the wallet SDK for your chain plus `fetch`.
+
+#### B.1 — Solana (USDC, facilitator pays gas)
+
+```javascript
+// npm i @solana/web3.js @solana/spl-token
+import {
+  Connection, Keypair, PublicKey,
+  TransactionMessage, VersionedTransaction, ComputeBudgetProgram,
+} from "@solana/web3.js";
+import { getAssociatedTokenAddress, createTransferCheckedInstruction } from "@solana/spl-token";
+
+const FACILITATOR = "https://facilitator.payai.network";
+const USDC_MINT   = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+const connection  = new Connection(process.env.SOLANA_RPC_URL || "https://api.mainnet-beta.solana.com");
+const keypair     = Keypair.fromSecretKey(Uint8Array.from(JSON.parse(process.env.SOLANA_PRIVATE_KEY)));
+
+async function payX402Solana(url, init = {}) {
+  // 1. Trigger the 402
+  let res = await fetch(url, init);
+  if (res.status !== 402) return res;              // nothing to pay
+  const body = await res.clone().json().catch(() => null);
+  const req  = (body?.accepts || []).find(a => a.network?.startsWith("solana"));
+  if (!req) throw new Error("No Solana payment option offered");
+
+  // 2. Build a USDC transfer where the FACILITATOR is the fee payer
+  const payTo     = new PublicKey(req.payTo);
+  const feePayer  = new PublicKey(req.extra.feePayer);      // PayAI pays gas, not you
+  const amount    = BigInt(req.maxAmountRequired || req.amount);
+  const sourceATA = await getAssociatedTokenAddress(USDC_MINT, keypair.publicKey);
+  const destATA   = await getAssociatedTokenAddress(USDC_MINT, payTo);
+  const { blockhash } = await connection.getLatestBlockhash();
+
+  const message = new TransactionMessage({
+    payerKey: feePayer,
+    recentBlockhash: blockhash,
+    instructions: [
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 30_000 }),
+      ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1 }),
+      createTransferCheckedInstruction(sourceATA, USDC_MINT, destATA, keypair.publicKey, amount, 6),
+    ],
+  });
+  const tx = new VersionedTransaction(message.compileToV0Message());
+  tx.sign([keypair]);                                        // you sign as the token owner; facilitator co-signs on settle
+
+  // 3. Encode the x402 payment payload and re-send the request with X-PAYMENT
+  const paymentPayload = {
+    x402Version: req.x402Version ?? 1,
+    scheme: "exact",
+    network: req.network,
+    payload: { transaction: Buffer.from(tx.serialize()).toString("base64") },
+  };
+  const header = Buffer.from(JSON.stringify(paymentPayload)).toString("base64");
+
+  res = await fetch(url, { ...init, headers: { ...(init.headers || {}), "X-PAYMENT": header } });
+  return res;                                                // 200 OK + X-PAYMENT-RESPONSE receipt header
+}
+```
+
+> **Some servers settle server-side** (they read your `X-PAYMENT` header, call the facilitator, then return the resource). **Others** — like the `sp3nd` skill in this repo — ask the client to call the facilitator's `/verify` then `/settle` directly and confirm out of band. Read the server's docs. The facilitator endpoints are: `POST /verify` and `POST /settle`, each taking `{ paymentPayload, paymentRequirements }` and returning `{ isValid }` / `{ success, transaction }`.
+
+#### B.2 — EVM (Base, Polygon, Arbitrum, …) via EIP-3009
+
+On EVM, the `exact` scheme uses an **EIP-3009 `transferWithAuthorization`** signature — you sign a typed message authorizing the transfer; no on-chain tx or gas from you at signing time. The payload is:
+
+```json
+{
+  "x402Version": 1,
+  "scheme": "exact",
+  "network": "base",
+  "payload": {
+    "signature": "0x…",
+    "authorization": {
+      "from": "0xYourWallet",
+      "to": "0xSellerWallet",
+      "value": "10000",
+      "validAfter": "0",
+      "validBefore": "1799999999",
+      "nonce": "0x…32bytes"
+    }
+  }
+}
+```
+
+Base64-encode that and send it as `X-PAYMENT`, exactly as in the Solana case. The easiest way to produce the signature correctly is the `x402-fetch` / `x402-axios` library (Option A), which handles the EIP-712 domain and nonce for you.
+
+## Choosing a facilitator
+
+A **facilitator** is a neutral service that verifies a payment is valid and broadcasts/settles it on-chain. This skill defaults to the **PayAI facilitator** because it is multi-chain and requires no signup:
+
+```
+https://facilitator.payai.network
+```
+
+Enumerate exactly what it supports at runtime:
+
+```bash
+curl -s https://facilitator.payai.network/supported | jq '.kinds[] | {scheme, network}'
+```
+
+As of writing, PayAI's facilitator settles **Solana** (mainnet + devnet, x402 v1 and v2) and **9 EVM chains** — Base, Avalanche, Sei, Polygon, X Layer, SKALE, and Arbitrum (v1 and v2, including the `upto` metered scheme). Always trust the live `/supported` response over this list.
+
+## Helper script
+
+`scripts/inspect-402.mjs` (zero dependencies, Node 18+) probes any URL and, if it returns `402`, decodes and pretty-prints the payment requirements — a safe dry run before you spend anything:
+
+```bash
+node scripts/inspect-402.mjs https://api.example.com/paid-endpoint
+```
+
+Use it to confirm the network, asset, amount, and `payTo` **before** wiring up a real payment.
+
+## Safety checklist for autonomous payments
+
+- **Verify the price.** Read `maxAmountRequired` and convert from base units (÷ 10^6 for USDC). Enforce a per-call and per-session spend cap.
+- **Verify the network + asset** against `/supported` — never pay in an asset or on a chain you didn't intend.
+- **Confirm `payTo`** matches the service you meant to pay when it matters (e.g. a known merchant wallet).
+- **Never expose private keys.** Load `SOLANA_PRIVATE_KEY` / EVM keys from the environment or a signer service — never hardcode them, never log them.
+- **Prefer devnet/testnet** (`solana-devnet`, `base-sepolia`) while developing.
+
+## Key facts
+
+- **Protocol:** x402 (`HTTP 402 Payment Required`) — payment as an HTTP header.
+- **Payment header (client → server):** `X-PAYMENT: base64(paymentPayload)`.
+- **Receipt header (server → client):** `X-PAYMENT-RESPONSE: base64(settlementReceipt)`.
+- **Default facilitator:** `https://facilitator.payai.network` (Solana + 9 EVM chains).
+- **USDC decimals:** 6 (so `1000000` base units = $1.00).
+- **USDC mint (Solana mainnet):** `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+- **USDC contract (Base mainnet):** `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
+- **Solana gas:** paid by the facilitator (`extra.feePayer`), not by you.
+- **Client libraries:** `x402-fetch`, `x402-axios`.
+- **Discover & sell x402 services:** see the [`payai`](../payai/) skill.
+- **Docs:** x402 protocol — https://x402.gitbook.io/x402 · PayAI facilitator — https://docs.payai.network

--- a/skills/x402/_meta.json
+++ b/skills/x402/_meta.json
@@ -1,0 +1,10 @@
+{
+  "owner": "PayAINetwork",
+  "slug": "x402",
+  "displayName": "x402 — Pay for Anything with USDC",
+  "latest": {
+    "version": "1.0.0",
+    "publishedAt": 1784871635427
+  },
+  "history": []
+}

--- a/skills/x402/scripts/inspect-402.mjs
+++ b/skills/x402/scripts/inspect-402.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// inspect-402.mjs — Probe a URL for x402 payment requirements WITHOUT paying.
+//
+// Usage:
+//   node inspect-402.mjs <url> [--method POST] [--data '{"k":"v"}'] [--header 'K: V']
+//
+// Prints, for each accepted payment option: network, asset, human-readable
+// amount, recipient (payTo), and the facilitator fee payer (Solana). Zero
+// dependencies — requires Node 18+ (global fetch).
+
+const args = process.argv.slice(2);
+if (args.length === 0 || args[0] === "-h" || args[0] === "--help") {
+  console.log("Usage: node inspect-402.mjs <url> [--method POST] [--data '<body>'] [--header 'K: V']");
+  process.exit(args.length === 0 ? 1 : 0);
+}
+
+const url = args[0];
+let method = "GET";
+let body;
+const headers = {};
+for (let i = 1; i < args.length; i++) {
+  if (args[i] === "--method") method = args[++i];
+  else if (args[i] === "--data") { body = args[++i]; method = method === "GET" ? "POST" : method; }
+  else if (args[i] === "--header") {
+    const raw = args[++i] || "";
+    const idx = raw.indexOf(":");
+    if (idx > -1) headers[raw.slice(0, idx).trim()] = raw.slice(idx + 1).trim();
+  }
+}
+if (body && !Object.keys(headers).some(h => h.toLowerCase() === "content-type")) {
+  headers["Content-Type"] = "application/json";
+}
+
+// Known assets, for friendly labels + decimals. Everything else defaults to 6.
+const ASSETS = {
+  EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: { symbol: "USDC", decimals: 6 }, // Solana
+  "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913":  { symbol: "USDC", decimals: 6 }, // Base
+};
+
+function describeAsset(asset) {
+  const info = ASSETS[asset] || ASSETS[String(asset).toLowerCase()];
+  return info || { symbol: "token", decimals: 6 };
+}
+
+function humanAmount(baseUnits, decimals) {
+  try {
+    const n = BigInt(baseUnits);
+    const d = BigInt(10) ** BigInt(decimals);
+    const whole = n / d;
+    const frac = (n % d).toString().padStart(decimals, "0").replace(/0+$/, "");
+    return frac ? `${whole}.${frac}` : `${whole}`;
+  } catch {
+    return String(baseUnits);
+  }
+}
+
+function printAccepts(accepts) {
+  accepts.forEach((a, i) => {
+    const asset = describeAsset(a.asset);
+    const amount = a.maxAmountRequired ?? a.amount;
+    console.log(`\n  [${i}] ${a.scheme || "exact"} on ${a.network}`);
+    console.log(`      price:   ${humanAmount(amount, asset.decimals)} ${asset.symbol}  (${amount} base units)`);
+    console.log(`      asset:   ${a.asset}`);
+    console.log(`      payTo:   ${a.payTo}`);
+    if (a.extra?.feePayer) console.log(`      feePayer:${" "}${a.extra.feePayer}  (facilitator pays Solana gas)`);
+    if (a.maxTimeoutSeconds) console.log(`      timeout: ${a.maxTimeoutSeconds}s`);
+    if (a.description) console.log(`      desc:    ${a.description}`);
+  });
+}
+
+const res = await fetch(url, { method, body, headers });
+console.log(`\n${method} ${url}\n→ HTTP ${res.status} ${res.statusText}`);
+
+if (res.status !== 402) {
+  console.log("\nNo payment required (status is not 402). Nothing to inspect.");
+  process.exit(0);
+}
+
+// x402 requirements can arrive in the JSON body OR a base64 PAYMENT-REQUIRED header.
+let parsed = null;
+const bodyText = await res.text();
+try { parsed = JSON.parse(bodyText); } catch { /* not JSON */ }
+
+const headerVal = res.headers.get("PAYMENT-REQUIRED") || res.headers.get("payment-required");
+if (!parsed?.accepts && headerVal) {
+  try { parsed = JSON.parse(Buffer.from(headerVal, "base64").toString("utf8")); } catch { /* ignore */ }
+}
+
+if (parsed?.accepts?.length) {
+  console.log(`\nx402 version: ${parsed.x402Version ?? "(unspecified)"}`);
+  console.log(`Payment options (${parsed.accepts.length}):`);
+  printAccepts(parsed.accepts);
+  console.log(`\nPick an option whose network you hold USDC on, then pay it (see SKILL.md).`);
+} else {
+  console.log("\nGot 402 but could not find an `accepts` array in the body or PAYMENT-REQUIRED header.");
+  console.log("Raw body:\n" + bodyText.slice(0, 2000));
+}


### PR DESCRIPTION
## Summary

Adds **two complementary skills** that let an OpenClaw agent **pay for and sell services over the [x402 protocol](https://x402.gitbook.io/x402)**, with first-class **Solana** support alongside EVM. This fills a gap in the collection: today `sp3nd` settles x402 payments through the [PayAI](https://payai.network) facilitator on Solana, but there's no general skill for *paying any* 402-gated resource or for *discovering* paid agent services.

| Skill | What it does |
|---|---|
| [`skills/x402`](skills/x402/) | The **client** skill. Detect an `HTTP 402`, build + sign a USDC payment on **Solana** (facilitator pays gas) or **EVM** (EIP-3009), retry with `X-PAYMENT`. Chain-agnostic, no SDK required. |
| [`skills/payai`](skills/payai/) | The **network** skill. Browse the PayAI **Bazaar** (`/discovery/resources`), use the multi-chain facilitator (`/supported`, `/verify`, `/settle`), and monetize your own endpoints as x402 resources. |

Each skill ships `SKILL.md` + `README.md` + `_meta.json` + a **zero-dependency helper script** (Node 18+).

## Verified against live infrastructure

Both helper scripts were run against the live PayAI facilitator before submitting:

- `payai/scripts/discover.mjs` — lists live Bazaar resources, filters by network (`--network solana`) and keyword, renders human-readable USDC amounts.
- `x402/scripts/inspect-402.mjs` — safely decodes the payment requirements of a real `402` response (network, asset, amount, `payTo`, Solana fee payer) **without spending**.

The supported-networks table and code examples are grounded in `GET https://facilitator.payai.network/supported` (Solana mainnet/devnet + 9 EVM chains).

## Checklist

- [x] Each skill has a valid `SKILL.md` with `name` + `description` frontmatter (openclaw `metadata` included, matching the `acp` skill)
- [x] No hardcoded API keys or personal credentials (keys read from env)
- [x] Helper scripts tested against the live facilitator
- [x] Clear, useful purpose; cross-linked with the existing `sp3nd` skill
- [x] Only adds `skills/x402/` and `skills/payai/` — the auto-generated `skill_index.md` / `README.md` tables are left for the weekly tooling

## Notes for reviewers

- The skills reference the standard `x402-fetch` / `x402-axios` client libs and `x402-express`/`-hono`/`-next` server middlewares as the recommended path, and document the raw HTTP flow as a no-SDK fallback (guaranteed correct against the facilitator API).
- Owner in `_meta.json` is set to `PayAINetwork`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)