### PR TITLE
feat(ai-model-router-v2): add MiniMax provider to cloud registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cp -r openclaw-master-skills/skills/<skill-name> ~/.openclaw/workspace/skills/
 
 | [`agentcreate`](skills/agentcreate/) | AI-powered OpenClaw agent creator — create and configure independent agents with model selection |
 | [`ai-model-router`](skills/ai-model-router/) | Intelligent AI model router, auto-switches between local and cloud models |
-| [`ai-model-router-v2`](skills/ai-model-router-v2/) | AI model router v2 — enhanced local/cloud auto-switching |
+| [`ai-model-router-v2`](skills/ai-model-router-v2/) | AI model router v2 — enhanced local/cloud auto-switching with MiniMax provider support |
 | [`ai-news-aggregator-sl`](skills/ai-news-aggregator-sl/) | Fetches AI & tech news or custom topics via aggregated feeds |
 | [`ai-task-hub`](skills/ai-task-hub/) | AI task hub for image analysis, background removal, speech-to-text, TTS, and more |
 | [`creative-toolkit`](skills/creative-toolkit/) | Multi-provider image generation — Nanobanana, Seedream, GPT Image |

--- a/skills/ai-model-router-v2/SKILL.md
+++ b/skills/ai-model-router-v2/SKILL.md
@@ -54,6 +54,23 @@ Your Request → Analyze → Select Model
 | CLI interface | ✓ |
 | **Core code size** | **~200 lines** |
 
+## MiniMax Provider
+
+The cloud registry includes the [MiniMax](https://platform.minimax.io/docs) text
+models below. Set `MINIMAX_API_KEY` to enable them.
+
+| Model | Context | Input | Thinking | Price (in/out $/M) |
+|-------|---------|-------|----------|--------------------|
+| MiniMax M3 | 1,000,000 | text, image, video | adaptive, disabled | 0.6 / 2.4 |
+| MiniMax M2.7 | 204,800 | text | always on | 0.3 / 1.2 |
+
+Both an OpenAI-compatible and an Anthropic-compatible endpoint are available per region:
+
+| Region | OpenAI base URL | Anthropic base URL |
+|--------|-----------------|--------------------|
+| Global (`global_en`) | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` |
+| China (`cn_zh`) | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` |
+
 ## CLI
 
 ```bash

--- a/skills/ai-model-router-v2/skill/modules/detector.py
+++ b/skills/ai-model-router-v2/skill/modules/detector.py
@@ -11,7 +11,7 @@ Security:
 import json
 import os
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 
 @dataclass
@@ -24,10 +24,33 @@ class ModelInfo:
     cost_score: float = 0
     power_score: float = 50
     capabilities: List[str] = None
+    # Optional cloud metadata (populated for providers that publish it)
+    context_window: Optional[int] = None
+    input_modalities: List[str] = None
+    thinking: List[str] = None
+    pricing_usd_per_million_tokens: Optional[dict] = None
+    openai_base_url: Optional[str] = None
+    anthropic_base_url: Optional[str] = None
 
     def __post_init__(self):
         if self.capabilities is None:
             self.capabilities = ["chat"]
+
+
+# Regional API endpoints for cloud providers that expose both an
+# OpenAI-compatible and an Anthropic-compatible interface per region.
+MINIMAX_ENDPOINTS = {
+    "global_en": {
+        "openai_base_url": "https://api.minimax.io/v1",
+        "anthropic_base_url": "https://api.minimax.io/anthropic",
+        "docs_root": "https://platform.minimax.io/docs",
+    },
+    "cn_zh": {
+        "openai_base_url": "https://api.minimaxi.com/v1",
+        "anthropic_base_url": "https://api.minimaxi.com/anthropic",
+        "docs_root": "https://platform.minimaxi.com/docs",
+    },
+}
 
 
 class ModelDetector:
@@ -102,7 +125,35 @@ class ModelDetector:
             ModelInfo("anthropic:claude-opus-4", "Claude Opus 4", "Anthropic", "cloud", 8, 95),
             ModelInfo("openai:gpt-4o-mini", "GPT-4o Mini", "OpenAI", "cloud", 1, 50),
             ModelInfo("openai:gpt-4o", "GPT-4o", "OpenAI", "cloud", 5, 85),
+            ModelInfo(
+                "minimax:MiniMax-M3", "MiniMax M3", "MiniMax", "cloud", 2, 90,
+                capabilities=["chat", "vision"],
+                context_window=1_000_000,
+                input_modalities=["text", "image", "video"],
+                thinking=["adaptive", "disabled"],
+                pricing_usd_per_million_tokens={
+                    "input": 0.6, "output": 2.4, "cache_read": 0.12, "cache_write": None,
+                },
+                openai_base_url=MINIMAX_ENDPOINTS["global_en"]["openai_base_url"],
+                anthropic_base_url=MINIMAX_ENDPOINTS["global_en"]["anthropic_base_url"],
+            ),
+            ModelInfo(
+                "minimax:MiniMax-M2.7", "MiniMax M2.7", "MiniMax", "cloud", 1, 70,
+                capabilities=["chat"],
+                context_window=204_800,
+                input_modalities=["text"],
+                thinking=["always_on"],
+                pricing_usd_per_million_tokens={
+                    "input": 0.3, "output": 1.2, "cache_read": 0.06, "cache_write": 0.375,
+                },
+                openai_base_url=MINIMAX_ENDPOINTS["global_en"]["openai_base_url"],
+                anthropic_base_url=MINIMAX_ENDPOINTS["global_en"]["anthropic_base_url"],
+            ),
         ]
+
+    def get_cloud_endpoints(self) -> dict:
+        """Return per-region API endpoints for multi-region cloud providers."""
+        return {"MiniMax": MINIMAX_ENDPOINTS}
 
     def detect_all(self) -> List[ModelInfo]:
         """Detect all available models"""

--- a/skills/ai-model-router-v2/tests/test_minimax_registry.py
+++ b/skills/ai-model-router-v2/tests/test_minimax_registry.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Unit tests for the MiniMax cloud provider entries in ai-model-router-v2.
+
+These tests only inspect the built-in registry; they make no network calls.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "skill"))
+
+from modules.detector import ModelDetector, MINIMAX_ENDPOINTS  # noqa: E402
+
+
+class TestMiniMaxRegistry(unittest.TestCase):
+    def setUp(self):
+        self.detector = ModelDetector()
+        registry = self.detector.get_cloud_registry()
+        self.by_id = {m.id: m for m in registry}
+        self.minimax = [m for m in registry if m.provider == "MiniMax"]
+
+    def test_provider_present(self):
+        """The cloud registry exposes the MiniMax provider."""
+        self.assertGreater(len(self.minimax), 0)
+        for m in self.minimax:
+            self.assertEqual(m.type, "cloud")
+
+    def test_current_models_registered(self):
+        """Both currently offered text models are registered."""
+        self.assertIn("minimax:MiniMax-M3", self.by_id)
+        self.assertIn("minimax:MiniMax-M2.7", self.by_id)
+
+    def test_m3_parameters(self):
+        m = self.by_id["minimax:MiniMax-M3"]
+        self.assertEqual(m.name, "MiniMax M3")
+        self.assertEqual(m.context_window, 1_000_000)
+        self.assertEqual(m.input_modalities, ["text", "image", "video"])
+        self.assertEqual(m.thinking, ["adaptive", "disabled"])
+        self.assertEqual(
+            m.pricing_usd_per_million_tokens,
+            {"input": 0.6, "output": 2.4, "cache_read": 0.12, "cache_write": None},
+        )
+        self.assertEqual(m.openai_base_url, "https://api.minimax.io/v1")
+        self.assertEqual(m.anthropic_base_url, "https://api.minimax.io/anthropic")
+
+    def test_m27_parameters(self):
+        m = self.by_id["minimax:MiniMax-M2.7"]
+        self.assertEqual(m.name, "MiniMax M2.7")
+        self.assertEqual(m.context_window, 204_800)
+        self.assertEqual(m.input_modalities, ["text"])
+        self.assertEqual(m.thinking, ["always_on"])
+        self.assertEqual(
+            m.pricing_usd_per_million_tokens,
+            {"input": 0.3, "output": 1.2, "cache_read": 0.06, "cache_write": 0.375},
+        )
+
+    def test_regional_endpoints(self):
+        """Global and CN regions expose OpenAI- and Anthropic-compatible URLs."""
+        endpoints = self.detector.get_cloud_endpoints()["MiniMax"]
+        self.assertEqual(endpoints, MINIMAX_ENDPOINTS)
+        self.assertEqual(
+            endpoints["global_en"]["openai_base_url"], "https://api.minimax.io/v1"
+        )
+        self.assertEqual(
+            endpoints["global_en"]["anthropic_base_url"],
+            "https://api.minimax.io/anthropic",
+        )
+        self.assertEqual(
+            endpoints["cn_zh"]["openai_base_url"], "https://api.minimaxi.com/v1"
+        )
+        self.assertEqual(
+            endpoints["cn_zh"]["anthropic_base_url"],
+            "https://api.minimaxi.com/anthropic",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reason: The ai-model-router-v2 cloud registry did not include the MiniMax provider, so its text models and regional API endpoints were unavailable.

## Changes

- Add the MiniMax text models to the `ai-model-router-v2` cloud registry (`skill/modules/detector.py`):
  - **MiniMax M3** — 1,000,000-token context; text, image and video input; `adaptive`/`disabled` thinking; pricing (USD per million tokens) input 0.6, output 2.4, cache read 0.12.
  - **MiniMax M2.7** — 204,800-token context; text input; always-on thinking; pricing input 0.3, output 1.2, cache read 0.06, cache write 0.375.
- Add per-region API endpoints exposing both an OpenAI-compatible and an Anthropic-compatible base URL, surfaced via `ModelDetector.get_cloud_endpoints()`:
  - Global (`global_en`): `https://api.minimax.io/v1` and `https://api.minimax.io/anthropic`.
  - China (`cn_zh`): `https://api.minimaxi.com/v1` and `https://api.minimaxi.com/anthropic`.
- Extend `ModelInfo` with optional metadata fields (`context_window`, `input_modalities`, `thinking`, `pricing_usd_per_million_tokens`, `openai_base_url`, `anthropic_base_url`) to carry these parameters; existing entries are unchanged.
- Document the provider, model parameters and regional endpoints in `SKILL.md`, and note MiniMax support in the catalog `README.md`.
- Add `tests/test_minimax_registry.py` validating the registry entries and endpoints.

## Checks

- `python3 -m py_compile skill/modules/detector.py skill/core/router.py tests/test_minimax_registry.py` — passed.
- `python3 -m unittest test_minimax_registry -v` — 5 tests passed.
